### PR TITLE
Add option for dummy entries

### DIFF
--- a/scripts/create_registry_db.py
+++ b/scripts/create_registry_db.py
@@ -38,6 +38,7 @@ cols.append(Column("is_external_link", Boolean, default=False))
 cols.append(Column("is_overwritable", Boolean, default=False))
 cols.append(Column("is_overwritten", Boolean, default=False))
 cols.append(Column("is_valid", Boolean, default=True)) # False if, e.g., copy failed
+cols.append(Column("is_dummy", Boolean, default=False)) # Is this a dummy dataset for testing
 
 # The following are boilerplate, included in all or most tables
 cols.append(Column("register_date", DateTime, nullable=False))

--- a/scripts/register_cli.py
+++ b/scripts/register_cli.py
@@ -38,7 +38,8 @@ def make_entry(args):
                                         creation_date=args.creation_date,
                                         description=args.description,
                                         old_location=args.old_location,
-                                        copy=(not args.make_sym_link))
+                                        copy=(not args.make_sym_link),
+                                        is_dummy=args.is_dummy)
 
     # new_id = registrar.register_dataset('my_favorite_dataset',
     #                                     'some_subdir/no_such_dataset.parquet',
@@ -73,6 +74,7 @@ parser.add_argument('--make-sym-link', action='store_true',
                             Ignored if old-location not specified.''')
 parser.add_argument('--schema-version', default=f'{SCHEMA_VERSION}')
 #                    help='By default use newest available schema version')
+parser.add_argument('--is_dummy', action="store_true", help="Dummy entry, don't copy any data")
 
 args = parser.parse_args()
 

--- a/src/dataregistry/registrar.py
+++ b/src/dataregistry/registrar.py
@@ -11,7 +11,6 @@ from dataregistry.exceptions import *
 
 __all__ = ['Registrar']
 _DEFAULT_ROOT_DIR = '/global/cfs/cdirs/desc-co/jrbogart/dregs_root' #temporary
-_DEFAULT_ROOT_DIR = "/home/mcalpine/Documents/dregs_root"
 
 class Registrar():
     '''
@@ -84,7 +83,7 @@ class Registrar():
                            * if True copy from old_location to relative_path.
                            * if False make sym link at relative_path
         is_dummy         True for dummy datasets. This copies no data, only creates
-                         and entry in the database (for testing only).
+                         an entry in the database (for testing only).
         verbose         Provide some additional output information
         '''
         if (self._owner_type == 'production') and is_overwritable:


### PR DESCRIPTION
When registering a dataset can include the --dummy parameter. This will create an entry in the table but it wont read or copy any actual data (this is for testing purposes)