### PR TITLE
Updated the automatic versioning in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools >= 61.0"] # PEP 621 compliant
+requires = ["setuptools" >= 61.0"] # PEP 621 compliant
 build-backend = "setuptools.build_meta"
 
 [project]
+dynamic = ["version"]
 name = "dataregistry"
-version = "0.1.1"
 description = "Creation and user API for DESC data registry."
 readme = "README.md"
 authors = [{ name = "Joanne Bogart", email = "jrb@slac.stanford.edu" }]
@@ -16,9 +16,12 @@ keywords = ["desc", "python", "registry"]
 dependencies = [
     'psycopg2',
     'sqlalchemy',
-    'importlib-metadata;python_version<"3.8"'
+    'pyaml',
 ]
 requires-python = ">=3.7" # For setuptools >= 61.0 support
+
+[tool.setuptools.dynamic]
+version = {attr = "dataregistry._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/dataregistry/__init__.py
+++ b/src/dataregistry/__init__.py
@@ -1,11 +1,4 @@
-try:
-    # For Python >= 3.8
-    from importlib import metadata
-except ImportError:
-    # For Python < 3.8
-    import importlib_metadata as metadata
-
-__version__ = metadata.version("dataregistry")
-
+from .version import __version__
 from .db_basic import *
 from .registrar import *
+


### PR DESCRIPTION
This now uses the way versioning is outlined in the [packaging repo](http://lsstdesc.org/desc-continuous-integration/desc/build_package/building_a_package.html#automatic-versioning)

Now the version is stored in src/dataregistry/_version.py and dynamically loaded in pyproject.toml

Also added pyaml as a dependency as it was missing