### PR TITLE
Options for query return dataset

### DIFF
--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -48,7 +48,7 @@ ALL_ORDERABLE = {sqltypes.INTEGER, sqltypes.FLOAT, sqltypes.DOUBLE,
 def is_orderable_type(ctype):
     return type(ctype) in ALL_ORDERABLE
 
-def _convert_alchemy_to_dict(result):
+def _convert_alchemy_to_dict(results):
     """
     Function to convert a sqlalchemy.engine.Result object to a dict.
 

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -48,6 +48,32 @@ ALL_ORDERABLE = {sqltypes.INTEGER, sqltypes.FLOAT, sqltypes.DOUBLE,
 def is_orderable_type(ctype):
     return type(ctype) in ALL_ORDERABLE
 
+def _convert_alchemy_to_dict(result):
+    """
+    Function to convert a sqlalchemy.engine.Result object to a dict.
+
+    Parameters
+    ----------
+    result : sqlalchemy.engine.Result object
+
+    Returns
+    -------
+    data : dict
+        Each row in the results table becomes a key
+    """
+
+    # Set up return dict
+    data = {}
+    for att in results.keys():
+        data[att] = []
+    
+    # Pull out the rows
+    for r in results:
+        for att in results.keys():
+        data[att].append(r._mapping[att])
+
+    return data
+
 class Query():
     '''
     Class implementing supported queries
@@ -174,7 +200,7 @@ class Query():
 
         return stmt.where(column_ref.__getattribute__(the_op)(value))
 
-    def find_datasets(self, property_names=None, filters=[]):
+    def find_datasets(self, property_names=None, filters=[], return_type=None):
         '''
         Get specified properties for datasets satisfying all filters
 
@@ -219,7 +245,14 @@ class Query():
                 print(e.StatementError.orig)
                 return None
 
-        return result
+        if return_type == "dict":
+            # Return a dict
+            return _convert_alchemy_to_dict(result)
+        elif return_type is None:
+            # Return a sqlalchemy.engine.Result object
+            return result
+        else:
+            raise ValueError(f"{return_type} is a bad return_type")
 
 if __name__ == '__main__':
     from dataregistry.db_basic import create_db_engine

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -70,7 +70,7 @@ def _convert_alchemy_to_dict(result):
     # Pull out the rows
     for r in results:
         for att in results.keys():
-        data[att].append(r._mapping[att])
+            data[att].append(r._mapping[att])
 
     return data
 

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -40,4 +40,4 @@ f = Filter('dataset.version_major', '<', 100)
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f], return_type="dict")
 assert type(results) == dict, "Bad return type from query 3"
 assert len(results.keys()) == 2, "Bad dict length in query 3"
-assert len(results["dataset_id"]) == 2, "Bad array length in query 3"
+assert len(results["dataset_id"]) == 4, "Bad array length in query 3"

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -25,12 +25,19 @@ assert len(execution_columns) == NUM_EXECUTION_COLUMNS, "Bad execution columns l
 
 # Do some queries on the test data.
 
-# Query 1: Query dataset name
+# Query on dataset name
 f = Filter('dataset.name', '==', 'DESC dataset 1')
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
 assert results.rowcount == 2, "Bad result from query 1"
 
-# Query 2: Query on version
+# Query on version
 f = Filter('dataset.version_major', '<', 100)
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
 assert results.rowcount == 4, "Bad result from query 2"
+
+# Query to check dataset return type
+f = Filter('dataset.version_major', '<', 100)
+results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f], return_type="dict")
+assert type(results) == dict, "Bad return type from query 3"
+assert len(results.keys()) == 2, "Bad dict length in query 3"
+assert len(results["dataset_id"]) == 2, "Bad array length in query 3"


### PR DESCRIPTION
Added an option `return_type` in queries.

By default it remains the alchemy row datatype, but the user can also now chose for a dict