### PR TITLE
U/jrbogart/name version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # emacs backup files
 *~
+
+# local stuff which doesn't belong in the repo
+local/

--- a/scripts/create_registry_db.py
+++ b/scripts/create_registry_db.py
@@ -31,6 +31,7 @@ cols.append(Column("relative_path", String, nullable=False))
 cols.append(Column("version_major", Integer, nullable=False))
 cols.append(Column("version_minor", Integer, nullable=False))
 cols.append(Column("version_patch", Integer, nullable=False))
+cols.append(Column("version_string", String, nullable=False))
 cols.append(Column("version_suffix", String))
 cols.append(Column("dataset_creation_date", DateTime))
 cols.append(Column("is_archived", Boolean, default=False))
@@ -63,7 +64,10 @@ cols.append(Column("nfiles", Integer, nullable=False))
 cols.append(Column("total_disk_space", Float, nullable=False))
 
 tab_creator.define_table("dataset", cols,
-                         [Index("relative_path", "owner", "owner_type")])
+                         [Index("relative_path", "owner", "owner_type"),
+                          UniqueConstraint("name", "version_string",
+                                           "version_suffix",
+                                           name="dataset_u_version")])
 
 # Dataset alias name table
 cols = []

--- a/scripts/register_cli.py
+++ b/scripts/register_cli.py
@@ -24,8 +24,8 @@ def make_entry(args):
     registrar = Registrar(engine, dialect, _lookup[args.owner_type],
                           owner=owner, schema_version=schema)
 
-    new_id = registrar.register_dataset(args.name, args.relpath,
-                                        args.version,
+    new_id = registrar.register_dataset(args.relpath,
+                                        args.version, name=args.name,
                                         version_suffix=args.version_suffix,
                                         creation_date=args.creation_date,
                                         description=args.description,
@@ -37,7 +37,7 @@ def make_entry(args):
 
 parser = argparse.ArgumentParser(description='''Register datasets with dataregistry''',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('name', help='A name for the dataset')
+parser.add_argument('--name', help='A name for the dataset. By default taken from relpath', default=None)
 parser.add_argument('relpath', help='''destination for dataset relative
   to <registry root>/<owner_type>/<owner>''')
 parser.add_argument('version', help='''

--- a/scripts/register_cli.py
+++ b/scripts/register_cli.py
@@ -24,13 +24,9 @@ def make_entry(args):
     registrar = Registrar(engine, dialect, _lookup[args.owner_type],
                           owner=owner, schema_version=schema)
 
-    v = args.version.split('.')
-    suffix = None
-    if len(v) > 3 and owner_type != 'production':
-        suffix = ''.join(v[3:])
     new_id = registrar.register_dataset(args.name, args.relpath,
-                                        v[0], v[1], v[2],
-                                        version_suffix=suffix,
+                                        args.version,
+                                        version_suffix=args.version_suffix,
                                         creation_date=args.creation_date,
                                         description=args.description,
                                         old_location=args.old_location,
@@ -44,11 +40,17 @@ parser = argparse.ArgumentParser(description='''Register datasets with dataregis
 parser.add_argument('name', help='A name for the dataset')
 parser.add_argument('relpath', help='''destination for dataset relative
   to <registry root>/<owner_type>/<owner>''')
-parser.add_argument('version', help='''Semantic version string of form m.n.p
-                 or m.n.p.stuff where m n p are nonneg. ints,
-                 stuff is an arbitrary string''')
+parser.add_argument('version', help='''
+                     Semantic version string of form m.n.p
+                     where m n p are nonneg. ints
+                     or one of the special values "patch", "minor", "major"
+                     ''')
+parser.add_argument('--version_suffix', default=None,
+                    help='''
+                    Version string suffix. Must be None for production
+                    ''')
 parser.add_argument('--owner-type', choices=['production', 'group', 'user'],
-                    default='user')
+                    default='user', help='Defaults to "user"')
 parser.add_argument('--owner', default=None,
                     help='defaults to current user for owner type user')
 parser.add_argument('--locale', default='NERSC')

--- a/src/dataregistry/.gitignore
+++ b/src/dataregistry/.gitignore
@@ -1,1 +1,0 @@
-_version.py

--- a/src/dataregistry/db_basic.py
+++ b/src/dataregistry/db_basic.py
@@ -2,7 +2,7 @@ from sqlalchemy import engine_from_config
 from sqlalchemy.engine import make_url
 import enum
 from sqlalchemy import MetaData, Table, Enum, Column, text, insert
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 import yaml
 import os
 from collections import namedtuple
@@ -45,9 +45,13 @@ def add_table_row(conn, table_meta, values):
         result = conn.execute(insert(table_meta), [values])
         conn.commit()
         return result.inserted_primary_key[0]
+    except IntegrityError as ei:
+        print('Original error:')
+        print(ei.orig)
+        return None
     except DBAPIError as e:
         print('Original error:')
-        print(e.StatementError.orig)
+        print(e.orig)
         return None
 
 class TableCreator:

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
     q = Query(engine, dialect, schema_version='registry_jrb')
     props = q.list_dataset_properties()
 
-    name_filter = Filter('dataset.name', '==', 'old.bashrc')
+    name_filter = Filter('dataset.name', '==', 'my_favorite_dataset')
     minor_filter = Filter('dataset.version_minor', '<', 2)
 
     results = q.find_datasets(['dataset.dataset_id', 'dataset.name',

--- a/src/dataregistry/registrar_util.py
+++ b/src/dataregistry/registrar_util.py
@@ -127,4 +127,12 @@ def calculate_special(name, v_string, v_suffix, dataset_table, engine):
             old_patch = int(r[2])
     v_fields = {'major' : old_major, 'minor' : old_minor, 'patch' : old_patch}
     v_fields[v_string] = v_fields[v_string] + 1
+
+    # reset fields as needed
+    if v_string == 'minor':
+        v_fields['patch'] = 0
+    if v_string == 'major':
+        v_fields['patch'] = 0
+        v_fields['minor'] = 0
+
     return v_fields

--- a/tests/ci/create_test_entries.py
+++ b/tests/ci/create_test_entries.py
@@ -57,10 +57,10 @@ def _insert_entry(name, relpath, version, owner_type, owner, description):
 
     # Add new entry.
     new_id = registrar.register_dataset(
-        name,
         relpath,
         version,
         version_suffix=version_suffix,
+        name=name,
         creation_date=creation_data,
         description=description,
         old_location=old_location,
@@ -98,6 +98,15 @@ _insert_entry(
     "user",
     None,
     "This is my second DESC dataset",
+)
+
+_insert_entry(
+    None,
+    "DESC/datasets/my_third_dataset.txt",
+    "0.2.1",
+    "user",
+    None,
+    "See if default name is correctly generated",
 )
 
 _insert_entry(

--- a/tests/ci/create_test_entries.py
+++ b/tests/ci/create_test_entries.py
@@ -46,7 +46,7 @@ def _insert_entry(name, relpath, version, owner_type, owner, description):
     make_sym_link = False
     schema_version = SCHEMA_VERSION
     is_dummy = True
-    version_suffix = ""
+    version_suffix = None
     if owner is None:
         owner = os.getenv("USER")
 
@@ -97,7 +97,7 @@ _insert_entry(
     "minor",
     "user",
     None,
-    "This is my first DESC dataset (updated)",
+    "This is my first DESC dataset (minor version update)",
 )
 
 _insert_entry(

--- a/tests/ci/create_test_entries.py
+++ b/tests/ci/create_test_entries.py
@@ -17,28 +17,6 @@ else:
 # Establish connection to database
 engine, dialect = create_db_engine(config_file=DREGS_CONFIG)
 
-
-def _parse_version(version_str):
-    """
-    Pull out the MAJOR.MINOR.PATCH integers from the version string.
-
-    Parameters
-    ----------
-    version_str : str
-        Format "M.N.P"
-
-    Returns
-    -------
-    M, N, P : int
-        Major, Minor, Patch version integers
-    """
-
-    v = version_str.split(".")
-    assert len(v) == 3, "Bad version string"
-
-    return int(v[0]), int(v[1]), int(v[2])
-
-
 def _insert_entry(name, relpath, version, owner_type, owner, description):
     """
     Wrapper to create dataset entry
@@ -78,14 +56,10 @@ def _insert_entry(name, relpath, version, owner_type, owner, description):
     )
 
     # Add new entry.
-    v_major, v_minor, v_patch = _parse_version(version)
-
     new_id = registrar.register_dataset(
         name,
         relpath,
-        v_major,
-        v_minor,
-        v_patch,
+        version,
         version_suffix=version_suffix,
         creation_date=creation_data,
         description=description,
@@ -112,6 +86,15 @@ _insert_entry(
     "DESC dataset 1",
     "DESC/datasets/my_first_dataset_v2",
     "0.0.2",
+    "user",
+    None,
+    "This is my first DESC dataset (updated)",
+)
+
+_insert_entry(
+    "DESC dataset 1",
+    "DESC/datasets/my_first_dataset_v2_minor_upgrade",
+    "minor",
     "user",
     None,
     "This is my first DESC dataset (updated)",

--- a/tests/ci/create_test_entries.py
+++ b/tests/ci/create_test_entries.py
@@ -84,15 +84,6 @@ _insert_entry(
 
 _insert_entry(
     "DESC dataset 1",
-    "DESC/datasets/my_first_dataset_v2",
-    "0.0.2",
-    "user",
-    None,
-    "This is my first DESC dataset (updated)",
-)
-
-_insert_entry(
-    "DESC dataset 1",
     "DESC/datasets/my_first_dataset_v2_minor_upgrade",
     "minor",
     "user",

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -34,3 +34,8 @@ assert results.rowcount == 2, "Bad result from query 1"
 f = Filter('dataset.version_major', '<', 100)
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
 assert results.rowcount == 4, "Bad result from query 2"
+
+# Query 3: Query on name for an entry where name was defaulted
+f = Filter('name', '==', 'my_third_dataset')
+results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
+assert results.rowcount == 1, "Bad result from query 3"

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -33,7 +33,7 @@ assert results.rowcount == 2, "Bad result from query 1"
 # Query 2: Query on version
 f = Filter('dataset.version_major', '<', 100)
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
-assert results.rowcount == 4, "Bad result from query 2"
+assert results.rowcount == 5, "Bad result from query 2"
 
 # Query 3: Query on name for an entry where name was defaulted
 f = Filter('name', '==', 'my_third_dataset')

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -36,6 +36,6 @@ results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
 assert results.rowcount == 5, "Bad result from query 2"
 
 # Query 3: Query on name for an entry where name was defaulted
-f = Filter('name', '==', 'my_third_dataset')
+f = Filter('dataset.name', '==', 'my_third_dataset')
 results = q.find_datasets(['dataset.dataset_id', 'dataset.name'], [f])
 assert results.rowcount == 1, "Bad result from query 3"

--- a/tests/ci/test_query.py
+++ b/tests/ci/test_query.py
@@ -2,7 +2,7 @@ from dataregistry.query import Query, Filter
 from dataregistry.db_basic import create_db_engine, ownertypeenum, SCHEMA_VERSION
 import os
 
-NUM_DATASET_COLUMNS = 23
+NUM_DATASET_COLUMNS = 24
 NUM_EXECUTION_COLUMNS = 7
 
 if os.getenv("DREGS_CONFIG") is None:

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -16,53 +16,94 @@ registrar = Registrar(engine, dialect, ownertypeenum.user, owner='jrbogart',
 
 new_id = registrar.register_execution('my_execution1', 'imaginary execution 1',
                                       locale='NERSC')
-print(f'Created execution entry with id {new_id}')
+if new_id:
+    print(f'Created execution entry with id {new_id}')
+else:
+    print(f'Failed to create execution entry')
+
 new_id = registrar.register_execution('my_execution2', 'imaginary execution 2',
                                       locale='NERSC')
-print(f'Created execution entry with id {new_id}')
+if new_id:
+    print(f'Created execution entry with id {new_id}')
+else:
+    print(f'Failed to create execution entry')
 
 new_id = registrar.register_execution('my_execution3', 'imaginary execution 3',
                                       locale='NERSC')
-print(f'Created execution entry with id {new_id}')
+if new_id:
+    print(f'Created execution entry with id {new_id}')
+else:
+    print(f'Failed to create execution entry')
+
 new_id = registrar.register_execution('my_execution4', 'imaginary execution 4',
                                       locale='NERSC')
-print(f'Created execution entry with id {new_id}')
+if new_id:
+    print(f'Created execution entry with id {new_id}')
+else:
+    print(f'Failed to create execution entry')
 
+new_id = registrar.register_dataset('some_subdir/no_such_dataset1.parquet',
+                                    '1.1.0',version_suffix='junk',
+                                    name='my_favorite_dataset',
+                                    description='Non-existent dataset',
+                                    is_overwritable=True, is_dummy=True)
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')
 
-new_id = registrar.register_dataset('my_favorite_dataset',
-                                    'some_subdir/no_such_dataset1.parquet',
+new_id = registrar.register_dataset('some_subdir/my_favorite_dataset.parquet',
                                     '1.1.0',version_suffix='junk',
                                     description='Non-existent dataset',
                                     is_overwritable=True, is_dummy=True)
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')
 
-print(f'Created dataset entry with id {new_id}')
-new_id = registrar.register_dataset('my_favorite_dataset',
-                                    'some_subdir/no_such_dataset3.parquet',
+
+new_id = registrar.register_dataset('some_subdir/no_such_dataset3.parquet',
                                     'patch',version_suffix='junk',
+                                    name='my_favorite_dataset',
                                     execution_id=2,
                                     description='Non-existent dataset',
                                     is_overwritable=True, is_dummy=True)
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')
 
-print(f'Created dataset entry with id {new_id}')
-new_id = registrar.register_dataset('my_favorite_dataset',
-                                    'some_subdir/no_such_dataset3.parquet',
+
+new_id = registrar.register_dataset('some_subdir/no_such_dataset3.parquet',
                                     'minor',version_suffix='junk',
+                                    name='my_favorite_dataset',
                                     execution_id=3,
                                     description='Non-existent dataset',
                                     is_overwritable=True, is_dummy=True)
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')
 
-print(f'Created dataset entry with id {new_id}')
-new_id = registrar.register_dataset('my_favorite_dataset',
-                                    'some_subdir/no_such_dataset3.parquet',
+
+new_id = registrar.register_dataset('some_subdir/no_such_dataset3.parquet',
                                     'major',version_suffix='junk',
+                                    name='my_favorite_dataset',
                                     execution_id=4,
                                     description='Non-existent dataset',
                                     is_overwritable=True, is_dummy=True)
-print(f'Created dataset entry with id {new_id}')
-new_id = registrar.register_dataset('another_favorite_dataset',
-                                    'some_subdir/another_nondataset4.parquet',
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')
+
+new_id = registrar.register_dataset('some_subdir/another_nondataset4.parquet',
                                     'major',version_suffix='junk',
+                                    name='another_favorite_dataset',
                                     execution_id=4,
                                     description='Non-existent dataset',
                                     is_overwritable=False, is_dummy=True)
-print(f'Created dataset entry with id {new_id}')
+if new_id:
+    print(f'Created dataset entry with id {new_id}')
+else:
+    print(f'Failed to create dataset entry')

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -13,14 +13,56 @@ else:
 registrar = Registrar(engine, dialect, ownertypeenum.user, owner='jrbogart',
                       schema_version=schema)
 
-new_id = registrar.register_execution('my_program', 'imaginary program',
+
+new_id = registrar.register_execution('my_execution1', 'imaginary execution 1',
+                                      locale='NERSC')
+print(f'Created execution entry with id {new_id}')
+new_id = registrar.register_execution('my_execution2', 'imaginary execution 2',
                                       locale='NERSC')
 print(f'Created execution entry with id {new_id}')
 
-new_id = registrar.register_dataset('my_favorite_dataset',
-                                    'some_subdir/no_such_dataset.parquet',
-                                    1,0,0,version_suffix='junk',
-                                    description='Non-existent dataset',
-                                    is_overwritable=True)
+new_id = registrar.register_execution('my_execution3', 'imaginary execution 3',
+                                      locale='NERSC')
+print(f'Created execution entry with id {new_id}')
+new_id = registrar.register_execution('my_execution4', 'imaginary execution 4',
+                                      locale='NERSC')
+print(f'Created execution entry with id {new_id}')
 
+
+new_id = registrar.register_dataset('my_favorite_dataset',
+                                    'some_subdir/no_such_dataset1.parquet',
+                                    '1.1.0',version_suffix='junk',
+                                    description='Non-existent dataset',
+                                    is_overwritable=True, is_dummy=True)
+
+print(f'Created dataset entry with id {new_id}')
+new_id = registrar.register_dataset('my_favorite_dataset',
+                                    'some_subdir/no_such_dataset3.parquet',
+                                    'patch',version_suffix='junk',
+                                    execution_id=2,
+                                    description='Non-existent dataset',
+                                    is_overwritable=True, is_dummy=True)
+
+print(f'Created dataset entry with id {new_id}')
+new_id = registrar.register_dataset('my_favorite_dataset',
+                                    'some_subdir/no_such_dataset3.parquet',
+                                    'minor',version_suffix='junk',
+                                    execution_id=3,
+                                    description='Non-existent dataset',
+                                    is_overwritable=True, is_dummy=True)
+
+print(f'Created dataset entry with id {new_id}')
+new_id = registrar.register_dataset('my_favorite_dataset',
+                                    'some_subdir/no_such_dataset3.parquet',
+                                    'major',version_suffix='junk',
+                                    execution_id=4,
+                                    description='Non-existent dataset',
+                                    is_overwritable=True, is_dummy=True)
+print(f'Created dataset entry with id {new_id}')
+new_id = registrar.register_dataset('another_favorite_dataset',
+                                    'some_subdir/another_nondataset4.parquet',
+                                    'major',version_suffix='junk',
+                                    execution_id=4,
+                                    description='Non-existent dataset',
+                                    is_overwritable=False, is_dummy=True)
 print(f'Created dataset entry with id {new_id}')


### PR DESCRIPTION
Change register_dataset call interface
* accept two string arguments: `version` and `version_suffix`. 
* `version` is required and must either be of form "k.m.n" where k, m, n are non-negative integers or
    one of "patch", "minor", "major".  
    `version_suffix` is optional and can be any string
* in the second case, new version numbers will be computed based on existing entries with the same `name` and `version_suffix` fields 