### PR TITLE
Auto build/publish docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
           pip install sphinx sphinx_rtd_theme sphinx_toolbox
       - name: Sphinx build
         run: |
-          sphinx-build docs _build
+          sphinx-build docs/source _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,22 @@
+name: Docs
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme sphinx_toolbox
+      - name: Sphinx build
+        run: |
+          sphinx-build docs _build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true


### PR DESCRIPTION
This CI will automatically build the documentation.

It will also publish the docs from the main branch to github pages for us. The built docs go into the "empty" `gh-pages` branch, which I've created.