### PR TITLE
Option to add db_backend and schema to the directory path

### DIFF
--- a/src/dataregistry/registrar.py
+++ b/src/dataregistry/registrar.py
@@ -137,7 +137,14 @@ class Registrar:
         """
 
         # Get destination directory in data registry.
-        dest = _form_dataset_path(owner_type, owner, relative_path, self.root_dir)
+        dest = _form_dataset_path(
+            self._dialect,
+            self._schema_version,
+            owner_type,
+            owner,
+            relative_path,
+            self.root_dir,
+        )
 
         # Is the data already on location, or coming from somewhere new?
         if old_location:
@@ -314,7 +321,7 @@ class Registrar:
             the data registry.
         copy : bool, optional
             True to copy data from ``old_location`` into the data registry
-            (default behaviour).  
+            (default behaviour).
             False to create a symlink.
         is_dummy : bool, optional
             True for "dummy" datasets (no data is copied, for testing purposes

--- a/src/dataregistry/registrar_util.py
+++ b/src/dataregistry/registrar_util.py
@@ -53,7 +53,9 @@ def _parse_version_string(version, with_suffix=False):
     return d
 
 
-def _form_dataset_path(owner_type, owner, relative_path, root_dir=None):
+def _form_dataset_path(
+    dialect, schema, owner_type, owner, relative_path, root_dir=None
+):
     """
     Construct full (or relative) path to dataset in the data registry.
 
@@ -62,6 +64,10 @@ def _form_dataset_path(owner_type, owner, relative_path, root_dir=None):
 
     Parameters
     ----------
+    dialect : str
+        Database backend
+    schema : str
+        Database schema used
     owner_type : ownertypeenum
         Type of dataset
     owner : str
@@ -78,7 +84,7 @@ def _form_dataset_path(owner_type, owner, relative_path, root_dir=None):
     """
     if owner_type == "production":
         owner = "production"
-    to_return = os.path.join(owner_type, owner, relative_path)
+    to_return = os.path.join(dialect, schema, owner_type, owner, relative_path)
     if root_dir:
         to_return = os.path.join(root_dir, to_return)
     return to_return

--- a/tests/end_to_end_tests/create_test_entries.py
+++ b/tests/end_to_end_tests/create_test_entries.py
@@ -3,30 +3,39 @@ import sys
 
 from dataregistry import DREGS
 
-_TEST_ROOT_DIR="DREGS_data"
+_TEST_ROOT_DIR = "DREGS_data"
 
 # Make root dir
 if not os.path.isdir(_TEST_ROOT_DIR):
     os.makedirs(_TEST_ROOT_DIR)
 
-# Make a few dummy files to enter into database.
-if not os.path.isdir(os.path.join(_TEST_ROOT_DIR, f"user/{os.getenv('USER')}/dummy_dir")):
-    os.makedirs(os.path.join(_TEST_ROOT_DIR, f"user/{os.getenv('USER')}/dummy_dir"))
+# Establish connection to database
+dregs = DREGS(root_dir=_TEST_ROOT_DIR)
 
-if not os.path.isdir(os.path.join("dummy_dir")):
-    os.makedirs(os.path.join("dummy_dir"))
+# Make a few dummy files to enter into database.
+tmp = os.path.join(
+    _TEST_ROOT_DIR,
+    dregs.Registrar._dialect,
+    dregs.Registrar._schema_version,
+    "user",
+    os.getenv("USER"),
+)
+
+if not os.path.isdir(os.path.join(tmp, "dummy_dir")):
+    os.makedirs(os.path.join(tmp, "dummy_dir"))
+
+if not os.path.isdir("dummy_dir"):
+    os.makedirs("dummy_dir")
 
 with open(os.path.join("dummy_dir", "file1.txt"), "w") as f:
     f.write("test")
-with open(os.path.join(_TEST_ROOT_DIR, f"user/{os.getenv('USER')}/dummy_dir", "file1.txt"), "w") as f:
+with open(os.path.join(tmp, "dummy_dir", "file1.txt"), "w") as f:
     f.write("test")
-with open(os.path.join(_TEST_ROOT_DIR, f"user/{os.getenv('USER')}/dummy_dir", "file2.txt"), "w") as f:
+with open(os.path.join(tmp, "dummy_dir", "file2.txt"), "w") as f:
     f.write("test")
-with open(os.path.join(_TEST_ROOT_DIR, f"user/{os.getenv('USER')}/", "file1.txt"), "w") as f:
+with open(os.path.join(tmp, "file1.txt"), "w") as f:
     f.write("test")
 
-# Establish connection to database
-dregs = DREGS(root_dir=_TEST_ROOT_DIR)
 
 def _insert_alias_entry(name, dataset_id, owner_type, owner):
     """
@@ -163,7 +172,7 @@ def _insert_dataset_entry(
         execution_id=execution_id,
         verbose=True,
         owner=owner,
-        owner_type=owner_type
+        owner_type=owner_type,
     )
 
     assert new_id is not None, "Trying to create a dataset that already exists"

--- a/tests/unit_tests/test_registrar_util.py
+++ b/tests/unit_tests/test_registrar_util.py
@@ -1,6 +1,12 @@
 from dataregistry.db_basic import ownertypeenum
-from dataregistry.registrar_util import _parse_version_string, _name_from_relpath, _form_dataset_path, get_directory_info
+from dataregistry.registrar_util import (
+    _parse_version_string,
+    _name_from_relpath,
+    _form_dataset_path,
+    get_directory_info,
+)
 import os
+
 
 def test_parse_version_string():
     """ Make sure version strings are parsed correctly """
@@ -30,6 +36,7 @@ def test_parse_version_string():
     assert tmp["minor"] == "8"
     assert tmp["patch"] == "9"
 
+
 def test_form_dataset_path():
     """
     Test dataset path construction
@@ -37,18 +44,27 @@ def test_form_dataset_path():
     Datasets should come back with the format:
         <root_dir>/<owner_type>/<owner>/<relative_path>
     """
-    
-    tmp = _form_dataset_path("production", "desc", "my/path", root_dir=None)
-    assert tmp == "production/production/my/path"
 
-    tmp = _form_dataset_path("production", "desc", "my/path", root_dir="my/root")
-    assert tmp == "my/root/production/production/my/path"
+    tmp = _form_dataset_path(
+        "sql_lite", "my_schema", "production", "desc", "my/path", root_dir=None
+    )
+    assert tmp == "sql_lite/my_schema/production/production/my/path"
 
-    tmp = _form_dataset_path("group", "desc", "my/path", root_dir=None)
-    assert tmp == "group/desc/my/path"
+    tmp = _form_dataset_path(
+        "postgres", "registry", "production", "desc", "my/path", root_dir="my/root"
+    )
+    assert tmp == "my/root/postgres/registry/production/production/my/path"
 
-    tmp = _form_dataset_path("user", "desc", "my/path", root_dir="/root/")
-    assert tmp == "/root/user/desc/my/path"
+    tmp = _form_dataset_path(
+        "postgres", "registry", "group", "desc", "my/path", root_dir=None
+    )
+    assert tmp == "postgres/registry/group/desc/my/path"
+
+    tmp = _form_dataset_path(
+        "postgres", "registry", "user", "desc", "my/path", root_dir="/root/"
+    )
+    assert tmp == "/root/postgres/registry/user/desc/my/path"
+
 
 def test_directory_info():
     """
@@ -61,10 +77,11 @@ def test_directory_info():
     assert num_files > 0
     assert total_size > 0
 
-def test_name_from_relpath():
-	""" Make sure names are exctracted from paths correctly """
 
-	assert _name_from_relpath("/testing/test") == "test"
-	assert _name_from_relpath("./testing/test") == "test"
-	assert _name_from_relpath("/testing/test/") == "test"
-	assert _name_from_relpath("test") == "test"
+def test_name_from_relpath():
+    """ Make sure names are exctracted from paths correctly """
+
+    assert _name_from_relpath("/testing/test") == "test"
+    assert _name_from_relpath("./testing/test") == "test"
+    assert _name_from_relpath("/testing/test/") == "test"
+    assert _name_from_relpath("test") == "test"


### PR DESCRIPTION
Small change to change the directory structure on disk, now:

`<root_dir>/<db_backend>/<schema>/<owner_type>/<owner>/<relative_path>`

I don't think anything changes from the user, the relative path is untouched.

Again note this is directed at the dregs class branch to minimized repetition when merging 