### PR TITLE
Fix bug where we have not specified any properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Directories created during CI
-tests/end_to_end_tests/DREGS_data/
+tests/end_to_end_tests/DataRegistry_data/
 tests/end_to_end_tests/dummy_dir/
 
 # Byte-compiled / optimized / DLL files

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -157,7 +157,7 @@ class Query:
         format. If they are in <column_name> format the column name must be
         unique through all tables in the database.
 
-        If column_names is None, return all tables.
+        column_names cannot be None.
 
         Parameters
         ----------

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -165,16 +165,12 @@ class Query:
             String list of database columns
         """
 
+        if column_names is None:
+            raise ValueError("column_names cannot be None")
+
         tables_required = set()
         column_list = []
         is_orderable_list = []
-
-        # In the case where column_names is None, we want all tables.
-        if column_names is None:
-            for t in self._table_list:
-                tables_required.add(t)
-
-            return tables_required, column_list, is_orderable_list
 
         # Determine the column name and table it comes from
         for p in column_names:
@@ -293,9 +289,6 @@ class Query:
         result : sqlAlchemy Result object
         """
 
-        # What tables are required for this query?
-        tables_required, _, _ = self._parse_selected_columns(property_names)
-
         # Construct query
 
         # No properties requested, return all from dataset table (only)
@@ -304,6 +297,10 @@ class Query:
 
         # Return the selected properties.
         else:
+            # What tables are required for this query?
+            tables_required, _, _ = self._parse_selected_columns(property_names)
+
+            # Construct SELECT
             stmt = select(*[text(p) for p in property_names])
 
             # Create joins

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -157,6 +157,8 @@ class Query:
         format. If they are in <column_name> format the column name must be
         unique through all tables in the database.
 
+        If column_names is None, return all tables.
+
         Parameters
         ----------
         column_names : list
@@ -166,6 +168,13 @@ class Query:
         tables_required = set()
         column_list = []
         is_orderable_list = []
+
+        # In the case where column_names is None, we want all tables.
+        if column_names is None:
+            for t in self._table_list:
+                tables_required.add(t)
+
+            return tables_required, column_list, is_orderable_list
 
         # Determine the column name and table it comes from
         for p in column_names:

--- a/tests/end_to_end_tests/test_query.py
+++ b/tests/end_to_end_tests/test_query.py
@@ -6,8 +6,15 @@ from dataregistry import DataRegistry
 datareg = DataRegistry(root_dir="DataRegistry_data")
 
 
+def test_query_all():
+    """Test a query where no properties are chosen, i.e., 'return *"""
+    results = datareg.Query.find_datasets()
+
+    assert results is not None
+
+
 def test_query_dataset_cli():
-    """ Test queries for the dataset table entered from the CLI script """
+    """Test queries for the dataset table entered from the CLI script"""
 
     # Query 1: Make sure we find all datasets entered using the CLI
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset")
@@ -18,7 +25,7 @@ def test_query_dataset_cli():
 
 
 def test_query_dataset():
-    """ Test queries for the dataset table """
+    """Test queries for the dataset table"""
 
     # Query 1: Query on dataset name
     f = datareg.Query.gen_filter("dataset.name", "==", "bumped_dataset")
@@ -96,7 +103,7 @@ def test_query_dataset():
 
 
 def test_query_dataset_alias():
-    """ Test queries of dataset alias table """
+    """Test queries of dataset alias table"""
 
     # Query 1: Query on dataset alias
     f = datareg.Query.gen_filter("dataset_alias.alias", "==", "nice_dataset_name")
@@ -111,7 +118,7 @@ def test_query_dataset_alias():
 
 
 def test_query_execution():
-    """ Test queries of execution table """
+    """Test queries of execution table"""
 
     # Query 1: Find the dependencies of an execution
     f = datareg.Query.gen_filter("execution.name", "==", "pipeline_stage_3")


### PR DESCRIPTION
When we do a query with `property_names=None` we were crashing, fixed this.