### PR TITLE
Tidy db connection

### DIFF
--- a/scripts/create_registry_db.py
+++ b/scripts/create_registry_db.py
@@ -21,9 +21,7 @@ parser.add_argument('--config', help="Path to the data registry config file")
 
 args = parser.parse_args()
 
-##engine, dialect = create_db_engine(config_file=args.config)
 db_connection = DbConnection(args.config, args.schema)
-##tab_creator = TableCreator(engine, dialect, schema=schema)
 tab_creator = TableCreator(db_connection)
 
 # Main table, a row per dataset

--- a/src/dataregistry/DataRegistry.py
+++ b/src/dataregistry/DataRegistry.py
@@ -44,18 +44,14 @@ class DataRegistry:
             True for more output.
         """
         # Establish connection to database
-        db_connection = DbConnection(config_file,
-                                     schema=schema_version,
-                                     verbose=verbose)
-        #engine, dialect = create_db_engine(config_file=config_file, verbose=verbose)
+        db_connection = DbConnection(
+            config_file, schema=schema_version, verbose=verbose
+        )
 
         # Create query object
         self.Query = Query(db_connection)
 
         # Create registrar object
         self.Registrar = Registrar(
-            db_connection,
-            owner=owner,
-            owner_type=owner_type,
-            root_dir=root_dir,
+            db_connection, owner=owner, owner_type=owner_type, root_dir=root_dir,
         )

--- a/src/dataregistry/db_basic.py
+++ b/src/dataregistry/db_basic.py
@@ -107,13 +107,13 @@ def add_table_row(conn, table_meta, values, commit=True):
 
 
 class DbConnection:
-    def __init__(self, config_file, schema=None, verbose=False):
+    def __init__(self, config_file=None, schema=None, verbose=False):
         """
         Simple class to act as container for connection
 
         Parameters
         ----------
-        config : str
+        config : str, optional
             Path to config file with low-level connection information.
             If None, default location is assumed
         schema : str, optional

--- a/tests/unit_tests/test_connection.py
+++ b/tests/unit_tests/test_connection.py
@@ -1,38 +1,32 @@
-from dataregistry.db_basic import SCHEMA_VERSION, create_db_engine
 from dataregistry.db_basic import DbConnection
 import os
 
 
 def test_connect_manual():
     """Test connection to database with manually passed config location"""
-    engine, dialect = create_db_engine(
+    conn = DbConnection(
         config_file=os.path.join(os.getenv("HOME"), ".config_reg_access"), verbose=True
     )
-    assert engine is not None
-    assert dialect is not None
+    assert conn.engine is not None
+    assert conn.dialect is not None
+    if conn.dialect != "sqlite":
+        assert conn.schema is not None
 
 
 def test_connect_env():
     """Test connection to database with DATAREG_CONFIG env set"""
     os.environ["DATAREG_CONFIG"] = os.path.join(os.getenv("HOME"), ".config_reg_access")
-    engine, dialect = create_db_engine(verbose=True)
-    assert engine is not None
-    assert dialect is not None
+    conn = DbConnection(verbose=True)
+    assert conn.engine is not None
+    assert conn.dialect is not None
+    if conn.dialect != "sqlite":
+        assert conn.schema is not None
 
 
 def test_connect_default():
     """Test connection to database with default config location"""
-    engine, dialect = create_db_engine(verbose=True)
-    assert engine is not None
-    assert dialect is not None
-
-def test_connection_class():
-    """
-    Test connection to database with default config location,
-    making use of class DbConnection
-    """
-    db_connection = DbConnection(None, verbose=True)
-    assert db_connection.engine is not None
-    assert db_connection.dialect is not None
-    if db_connection.dialect != 'sqlite':
-        assert db_connection.schema is not None
+    conn = DbConnection(verbose=True)
+    assert conn.engine is not None
+    assert conn.dialect is not None
+    if conn.dialect != "sqlite":
+        assert conn.schema is not None


### PR DESCRIPTION
Fold the `create_db_engine` into the `DbConnection` class, and fix the tests to reflect that.

The function was a bit out of place, this tidies the code a little, keeping everything related to the connected within the `DbConnection` object.