### PR TITLE
Add ability to define execution name when registering a dataset

### DIFF
--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -27,7 +27,9 @@ arg_ls.add_argument(
     help="List datasets for a given owner type",
     choices=["user", "group", "production"],
 )
-arg_ls.add_argument("--config_file", help="Location of data registry config file", type=str)
+arg_ls.add_argument(
+    "--config_file", help="Location of data registry config file", type=str
+)
 arg_ls.add_argument("--all", help="List all datasets", action="store_true")
 
 # ------------------
@@ -122,15 +124,10 @@ arg_register_dataset.add_argument(
     action="store_true",
 )
 arg_register_dataset.add_argument(
-    "--schema",
-    default=f"{SCHEMA_VERSION}",
-    help="Which schema to connect to",
+    "--schema", default=f"{SCHEMA_VERSION}", help="Which schema to connect to",
 )
 arg_register_dataset.add_argument(
-    "--locale",
-    help="Location where dataset was produced",
-    type=str,
-    default="NERSC",
+    "--locale", help="Location where dataset was produced", type=str, default="NERSC",
 )
 arg_register_dataset.add_argument(
     "--owner", help="Owner of dataset. Defaults to $USER."
@@ -140,6 +137,30 @@ arg_register_dataset.add_argument(
 )
 arg_register_dataset.add_argument(
     "--config_file", help="Location of data registry config file", type=str
+)
+arg_register_dataset.add_argument(
+    "--execution_name", help="Typically pipeline name or program name", type=str
+)
+arg_register_dataset.add_argument(
+    "--execution_description", help="Human readible description of execution", type=str
+)
+arg_register_dataset.add_argument(
+    "--execution_start", help="Date the execution started"
+)
+arg_register_dataset.add_argument(
+    "--execution_locale", help="Where was the execution performed?", type=str
+)
+arg_register_dataset.add_argument(
+    "--execution_configuration",
+    help="Path to text file used to configure the execution",
+    type=str,
+)
+arg_register_dataset.add_argument(
+    "--input_datasets",
+    help="List of dataset ids that were the input to this execution",
+    type=int,
+    default=[],
+    nargs="+",
 )
 
 

--- a/src/cli/register.py
+++ b/src/cli/register.py
@@ -25,7 +25,13 @@ def register_dataset(args):
         old_location=args.old_location,
         copy=(not args.make_symlink),
         is_dummy=args.is_dummy,
-        owner=args.owner
+        owner=args.owner,
+        execution_name=args.execution_name,
+        execution_description=args.execution_description,
+        execution_start=args.execution_start,
+        execution_locale=args.execution_locale,
+        execution_configuration=args.execution_configuration,
+        input_datasets=args.input_datasets
     )
 
     print(f"Created dataset entry with id {new_id}")

--- a/src/dataregistry/registrar.py
+++ b/src/dataregistry/registrar.py
@@ -25,11 +25,7 @@ _OWNER_TYPES = {"user", "project", "group", "production"}
 
 class Registrar:
     def __init__(
-        self,
-        db_connection,
-        owner=None,
-        owner_type=None,
-        root_dir=None,
+        self, db_connection, owner=None, owner_type=None, root_dir=None,
     ):
         """
         Class to register new datasets, executions and alias names.
@@ -304,6 +300,12 @@ class Registrar:
         verbose=False,
         owner=None,
         owner_type=None,
+        execution_name=None,
+        execution_description=None,
+        execution_start=None,
+        execution_locale=None,
+        execution_configuration=None,
+        input_datasets=[],
     ):
         """
         Register a new dataset in the DESC data registry.
@@ -360,6 +362,18 @@ class Registrar:
             Owner type: "user", "group", or "production". If None, defaults to
             what was set in Registrar __init__, if that is also None, defaults
             to "user".
+        execution_name : str, optional
+            Typically pipeline name or program name
+        execution_description : str, optional
+            Human readible description of execution
+        execution_start : datetime, optional
+            Date the execution started
+        execution_locale : str, optional
+            Where was the execution performed?
+        execution_configuration : str, optional
+            Path to text file used to configure the execution
+        input_datasets : list, optional
+            List of dataset ids that were the input to this execution
 
         Returns
         -------
@@ -436,11 +450,20 @@ class Registrar:
 
         # If no execution_id is supplied, create a minimal entry
         if execution_id is None:
-            ex_name = f"for_dataset_{name}-{version_string}"
-            if version_suffix:
-                ex_name = f"{ex_name}-{version_suffix}"
-            descr = "Fabricated execution for dataset"
-            execution_id = self.register_execution(ex_name, description=descr)
+            if execution_name is None:
+                execution_name = f"for_dataset_{name}-{version_string}"
+                if version_suffix:
+                    execution_name = f"{execution_name}-{version_suffix}"
+            if execution_description is None:
+                execution_description = "Fabricated execution for dataset"
+            execution_id = self.register_execution(
+                execution_name,
+                description=execution_description,
+                execution_start=execution_start,
+                locale=execution_locale,
+                configuration=execution_configuration,
+                input_datasets=input_datasets,
+            )
             if execution_id is None:
                 return None
 

--- a/src/dataregistry/registrar.py
+++ b/src/dataregistry/registrar.py
@@ -379,6 +379,8 @@ class Registrar:
         -------
         prim_key : int
             The dataset ID of the new row relating to this entry (else None)
+        execution_id : int
+            The execution ID associated with the dataset
         """
 
         # Make sure the owner_type is legal
@@ -464,8 +466,6 @@ class Registrar:
                 configuration=execution_configuration,
                 input_datasets=input_datasets,
             )
-            if execution_id is None:
-                return None
 
         # Pull the dataset properties together
         values = {"name": name}
@@ -511,7 +511,7 @@ class Registrar:
                 conn.execute(update_stmt)
             conn.commit()
 
-        return prim_key
+        return prim_key, execution_id
 
     def register_dataset_alias(self, aliasname, dataset_id):
         """

--- a/tests/end_to_end_tests/create_test_entries.py
+++ b/tests/end_to_end_tests/create_test_entries.py
@@ -201,8 +201,9 @@ def _insert_dataset_entry(
         input_datasets=input_datasets
     )
 
-    assert new_id is not None, "Trying to create a dataset that already exists"
-    print(f"Created dataset entry with id {new_id}")
+    assert dataset_id is not None, "Trying to create a dataset that already exists"
+    assert execution_id is not None, "Trying to create a execution that already exists"
+    print(f"Created dataset entry with id {dataset_id}")
 
     return dataset_id
 

--- a/tests/end_to_end_tests/create_test_entries.py
+++ b/tests/end_to_end_tests/create_test_entries.py
@@ -112,6 +112,12 @@ def _insert_dataset_entry(
     old_location=None,
     is_overwritable=False,
     which_datareg=None,
+    execution_name=None,
+    execution_description=None,
+    execution_start=None,
+    execution_locale=None,
+    execution_configuration=None,
+    input_datasets=[],
 ):
     """
     Wrapper to create dataset entry
@@ -142,6 +148,18 @@ def _insert_dataset_entry(
         Path to data to be copied to data registry
     which_datareg : DataRegistry object
         In case we want to register using a custom DataRegistry object
+    execution_name : str, optional
+            Typically pipeline name or program name
+    execution_description : str, optional
+        Human readible description of execution
+    execution_start : datetime, optional
+        Date the execution started
+    execution_locale : str, optional
+        Where was the execution performed?
+    execution_configuration : str, optional
+        Path to text file used to configure the execution
+    input_datasets : list, optional
+        List of dataset ids that were the input to this execution
 
     Returns
     -------
@@ -174,7 +192,13 @@ def _insert_dataset_entry(
         verbose=True,
         owner=owner,
         owner_type=owner_type,
-        is_overwritable=is_overwritable
+        is_overwritable=is_overwritable,
+        execution_name=execution_name,
+        execution_description=execution_description,
+        execution_start=execution_start,
+        execution_locale=execution_locale,
+        execution_configuration=execution_configuration,
+        input_datasets=input_datasets
     )
 
     assert new_id is not None, "Trying to create a dataset that already exists"
@@ -416,7 +440,7 @@ _insert_dataset_entry(
     old_location=None,
 )
 
-# Tests set 11
+# Test set 11
 # - Test global owner and owner types in the DataRegistry/Registar class
 datareg2 = DataRegistry(root_dir=_TEST_ROOT_DIR, owner="DESC group", owner_type="group")
 
@@ -427,4 +451,18 @@ _insert_dataset_entry(
     None,
     "This should be owned by 'DESC group' and have owner_type='group'",
     which_datareg=datareg2
+)
+
+# Test set 12
+# - Testing execution creation directly through dataset registration
+_insert_dataset_entry(
+    "DESC/datasets/execution_test",
+    "0.0.1",
+    None,
+    None,
+    "This should have a more descriptive execution",
+    execution_name="Overwrite execution auto name",
+    execution_description="Overwrite execution auto description",
+    execution_locale="TestMachine",
+    input_datasets=[dataset_id_1],
 )

--- a/tests/end_to_end_tests/create_test_entries.py
+++ b/tests/end_to_end_tests/create_test_entries.py
@@ -163,7 +163,7 @@ def _insert_dataset_entry(
 
     Returns
     -------
-    new_id : int
+    dataset_id : int
         The dataset it created for this entry
     """
 
@@ -178,7 +178,7 @@ def _insert_dataset_entry(
     make_sym_link = False
 
     # Add new entry.
-    new_id = this_datareg.Registrar.register_dataset(
+    dataset_id, execution_id = this_datareg.Registrar.register_dataset(
         relpath,
         version,
         version_suffix=version_suffix,
@@ -204,7 +204,7 @@ def _insert_dataset_entry(
     assert new_id is not None, "Trying to create a dataset that already exists"
     print(f"Created dataset entry with id {new_id}")
 
-    return new_id
+    return dataset_id
 
 
 # Test set 1

--- a/tests/end_to_end_tests/test_query.py
+++ b/tests/end_to_end_tests/test_query.py
@@ -126,6 +126,34 @@ def test_query_dataset():
             else:
                 raise ValueError("Bad patch number")
 
+    # Query 9: Check dataset execution is made correctly
+    f = datareg.Query.gen_filter(
+        "dataset.relative_path", "==", "DESC/datasets/execution_test"
+    )
+    results = datareg.Query.find_datasets(["dataset.execution_id"], [f])
+
+    ex_id = results.fetchone().execution_id
+    f = datareg.Query.gen_filter("execution.execution_id", "==", ex_id)
+    results = datareg.Query.find_datasets(
+        ["execution.name", "execution.description"], [f]
+    )
+
+    for r in results:
+        assert r.name == "Overwrite execution auto name"
+        assert r.description == "Overwrite execution auto description"
+
+    f = datareg.Query.gen_filter(
+        "dataset.relative_path", "==", "DESC/datasets/my_first_pipeline_stage1"
+    )
+    results = datareg.Query.find_datasets(["dataset.dataset_id"], [f])
+    input_id = results.fetchone()[0]
+
+    f = datareg.Query.gen_filter("dependency.execution_id", "==", ex_id)
+    results = datareg.Query.find_datasets(["dependency.input_id"], [f])
+
+    for r in results:
+        assert r.input_id == input_id
+
 
 def test_query_dataset_alias():
     """Test queries of dataset alias table"""


### PR DESCRIPTION
Currently when registering a dataset with no execution, a default execution is made for the dataset.

Now you can modify the metadata of this default execution during dataset registration. So if you just have one dataset in an exectuion, this saves the user having to make an execution first, then assigning a dataset to it, it can all be done at dataset registration.

Executions with more than one dataset associated with them still need the execution to be made first.