### PR TITLE
Add the original registering `root_dir` to the database table 

### DIFF
--- a/scripts/create_registry_db.py
+++ b/scripts/create_registry_db.py
@@ -192,6 +192,8 @@ def _Dataset(schema):
         "data_org": Column("data_org", String, nullable=False),
         "nfiles": Column("nfiles", Integer, nullable=False),
         "total_disk_space": Column("total_disk_space", Float, nullable=False),
+        # What `root_dir` was the data originially ingested into
+        "register_root_dir": Column(String, nullable=False),
     }
 
     # Table metadata

--- a/src/dataregistry/registrar.py
+++ b/src/dataregistry/registrar.py
@@ -524,6 +524,7 @@ class Registrar:
         values["data_org"] = dataset_organization
         values["nfiles"] = num_files
         values["total_disk_space"] = total_size / 1024 / 1024  # Mb
+        values["register_root_dir"] = self._root_dir
 
         # Create a new row in the data registry database.
         with self._engine.connect() as conn:


### PR DESCRIPTION
To keep tack of where the dataset (data) was originally ingested, put the registering `root_dir` as a field in the `dataset` table.

This means we should know that the data is always at least at this location. 