### PR TITLE
Add ability to delete datasets

### DIFF
--- a/src/dataregistry/registrar/base_table_class.py
+++ b/src/dataregistry/registrar/base_table_class.py
@@ -1,6 +1,19 @@
 import os
 
 from dataregistry.db_basic import TableMetadata
+from sqlalchemy import select, update
+from datetime import datetime
+
+from .registrar_util import (
+    _bump_version,
+    _copy_data,
+    _form_dataset_path,
+    _name_from_relpath,
+    _parse_version_string,
+    _read_configuration_file,
+    get_directory_info,
+)
+from .dataset_util import set_dataset_status, get_dataset_status
 
 # Allowed owner types
 _OWNER_TYPES = {"user", "project", "group", "production"}
@@ -68,59 +81,10 @@ class BaseTable:
         Parameters
         ----------
         entry_id : int
-            The dataset/execution/etc ID we wish to delete from the database
+            Entry we want to delete from the registry
         """
 
         raise NotImplementedError
-
-        """
-        Delete a dataset entry from the DESC data registry.
-
-        This will remove the raw data from the root dir, but the dataset entry
-        remains in the registry (now with `status=3`).
-
-        Parameters
-        ----------
-        dataset_id : int
-            Dataset we want to delete from the registry
-        """
-
-#        # First make sure the given dataset id is in the registry
-#        dataset_table = self.parent._get_table_metadata("dataset")
-#        previous_dataset = self._find_previous(dataset_table, dataset_id=dataset_id)
-#
-#        if previous_dataset is None:
-#            raise ValueError(f"Dataset ID {dataset_id} does not exist")
-#        if previous_dataset.status not in [0, 1]:
-#            raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
-#
-#        # Update the status of the dataset to deleted
-#        with self.parent._engine.connect() as conn:
-#            update_stmt = (
-#                update(dataset_table)
-#                .where(dataset_table.c.dataset_id == dataset_id)
-#                .values(
-#                    status=3,
-#                    delete_date=datetime.now(),
-#                    delete_uid=self.parent._uid,
-#                )
-#            )
-#            conn.execute(update_stmt)
-#            conn.commit()
-#
-#        # Delete the physical data in the root_dir
-#        if previous_dataset.status == 1:
-#            data_path = _form_dataset_path(
-#                previous_dataset.owner_type,
-#                previous_dataset.owner,
-#                previous_dataset.relative_path,
-#                schema=self.parent._schema,
-#                root_dir=self.parent._root_dir,
-#            )
-#            print(f"Deleting data {data_path}")
-#            os.remove(data_path)
-#
-#        print(f"Deleted {dataset_id} from data registry")
 
     def modify(self, entry_id, modify_fields):
         """

--- a/src/dataregistry/registrar/base_table_class.py
+++ b/src/dataregistry/registrar/base_table_class.py
@@ -28,7 +28,7 @@ class BaseTable:
         Base class to register/modify/delete entries in the database tables.
 
         Each table subclass (e.g., DatasetTable) will inherit this class.
-        
+
         Functions universal to all tables, such as delete and modify are
         written here, the register function, and other unique functions for the
         tables, are in their respective subclasses.
@@ -100,3 +100,38 @@ class BaseTable:
         """
 
         raise NotImplementedError
+
+    def find_entry(self, entry_id):
+        """
+        Find an entry in the database.
+
+        Parameters
+        ----------
+        entry_id : int
+            Unique identifier for table entry
+            e.g., dataset_id for the dataset table
+
+        Returns
+        -------
+        r : CursorResult object
+            Found entry (None if no entry found)
+        """
+
+        # Search for dataset in the registry.
+        my_table = self._get_table_metadata(self.which_table)
+
+        if self.which_table == "dataset":
+            stmt = select(my_table).where(my_table.c.dataset_id == entry_id)
+        else:
+            raise ValueError("Can only perform `find_entry` on dataset table for now")
+
+        with self._engine.connect() as conn:
+            result = conn.execute(stmt)
+            conn.commit()
+
+        # Pull out the single result
+        for r in result:
+            return r
+
+        # No results found
+        return None

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -1,6 +1,7 @@
 import os
 import time
 from datetime import datetime
+import shutil
 
 from dataregistry.db_basic import add_table_row
 from sqlalchemy import select, update
@@ -471,6 +472,9 @@ class DatasetTable(BaseTable):
                 root_dir=self._root_dir,
             )
             print(f"Deleting data {data_path}")
-            os.remove(data_path)
+            if os.path.isfile(data_path):
+                os.remove(data_path)
+            else:
+                shutil.rmtree(data_path)
 
         print(f"Deleted {dataset_id} from data registry")

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -7,450 +7,481 @@ from sqlalchemy import select, update
 
 from .base_table_class import BaseTable
 from .registrar_util import (
-    _bump_version,
-    _copy_data,
-    _form_dataset_path,
-    _name_from_relpath,
-    _parse_version_string,
-    _read_configuration_file,
-    get_directory_info,
+	_bump_version,
+	_copy_data,
+	_form_dataset_path,
+	_name_from_relpath,
+	_parse_version_string,
+	_read_configuration_file,
+	get_directory_info,
 )
 from .dataset_util import set_dataset_status, get_dataset_status
 
 
 class DatasetTable(BaseTable):
-    def __init__(self, db_connection, root_dir, owner, owner_type, execution_table):
-        super().__init__(db_connection, root_dir, owner, owner_type)
+	def __init__(self, db_connection, root_dir, owner, owner_type, execution_table):
+		super().__init__(db_connection, root_dir, owner, owner_type)
 
-        self.execution_table = execution_table
-        self.which_table = "dataset"
+		self.execution_table = execution_table
+		self.which_table = "dataset"
 
-    def register(
-        self,
-        relative_path,
-        version,
-        version_suffix=None,
-        name=None,
-        creation_date=None,
-        description=None,
-        execution_id=None,
-        access_API=None,
-        access_API_configuration=None,
-        is_overwritable=False,
-        old_location=None,
-        copy=True,
-        is_dummy=False,
-        verbose=False,
-        owner=None,
-        owner_type=None,
-        execution_name=None,
-        execution_description=None,
-        execution_start=None,
-        execution_locale=None,
-        execution_configuration=None,
-        input_datasets=[],
-        input_production_datasets=[],
-        max_config_length=None,
-    ):
-        """
-        Create a new dataset entry in the DESC data registry.
+	def register(
+		self,
+		relative_path,
+		version,
+		version_suffix=None,
+		name=None,
+		creation_date=None,
+		description=None,
+		execution_id=None,
+		access_API=None,
+		access_API_configuration=None,
+		is_overwritable=False,
+		old_location=None,
+		copy=True,
+		is_dummy=False,
+		verbose=False,
+		owner=None,
+		owner_type=None,
+		execution_name=None,
+		execution_description=None,
+		execution_start=None,
+		execution_locale=None,
+		execution_configuration=None,
+		input_datasets=[],
+		input_production_datasets=[],
+		max_config_length=None,
+	):
+		"""
+		Create a new dataset entry in the DESC data registry.
 
-        Any args marked with '**' share their name with the associated column
-        in the registry schema. Descriptions of what these columns are can be
-        found in `schema.yaml` or the documentation.
+		Any args marked with '**' share their name with the associated column
+		in the registry schema. Descriptions of what these columns are can be
+		found in `schema.yaml` or the documentation.
 
-        First, the dataset entry is created in the database. If success, the
-        data is then copied (if `old_location` was provided). Only if both
-        steps are successful will there be "valid" status entry in the
-        registry.
+		First, the dataset entry is created in the database. If success, the
+		data is then copied (if `old_location` was provided). Only if both
+		steps are successful will there be "valid" status entry in the
+		registry.
 
-        Parameters
-        ----------
-        relative_path** : str
-        version** : str
-        version_suffix** : str, optional
-        name** : str, optional
-        creation_date** : datetime, optional
-        description** : str, optional
-        execution_id** : int, optional
-        access_API** : str, optional
-        is_overwritable** : bool, optional
-        old_location : str, optional
-            Absolute location of dataset to copy into the data registry.
+		Parameters
+		----------
+		relative_path** : str
+		version** : str
+		version_suffix** : str, optional
+		name** : str, optional
+		creation_date** : datetime, optional
+		description** : str, optional
+		execution_id** : int, optional
+		access_API** : str, optional
+		is_overwritable** : bool, optional
+		old_location : str, optional
+			Absolute location of dataset to copy into the data registry.
 
-            If None, dataset should already be at correct relative_path within
-            the data registry.
-        copy : bool, optional
-            True to copy data from ``old_location`` into the data registry
-            (default behaviour).
-            False to create a symlink.
-        is_dummy : bool, optional
-            True for "dummy" datasets (no data is copied, for testing purposes
-            only)
-        verbose : bool, optional
-            Provide some additional output information
-        owner** : str, optional
-        owner_type** : str, optional
-        execution_name** : str, optional
-        execution_description** : str, optional
-        execution_start** : datetime, optional
-        execution_locale** : str, optional
-        execution_configuration** : str, optional
-        input_datasets : list, optional
-            List of dataset ids that were the input to this execution
-        input_production_datasets : list, optional
-            List of production dataset ids that were the input to this execution
-        max_config_length : int, optional
-            Maxiumum number of lines to read from a configuration file
+			If None, dataset should already be at correct relative_path within
+			the data registry.
+		copy : bool, optional
+			True to copy data from ``old_location`` into the data registry
+			(default behaviour).
+			False to create a symlink.
+		is_dummy : bool, optional
+			True for "dummy" datasets (no data is copied, for testing purposes
+			only)
+		verbose : bool, optional
+			Provide some additional output information
+		owner** : str, optional
+		owner_type** : str, optional
+		execution_name** : str, optional
+		execution_description** : str, optional
+		execution_start** : datetime, optional
+		execution_locale** : str, optional
+		execution_configuration** : str, optional
+		input_datasets : list, optional
+			List of dataset ids that were the input to this execution
+		input_production_datasets : list, optional
+			List of production dataset ids that were the input to this execution
+		max_config_length : int, optional
+			Maxiumum number of lines to read from a configuration file
 
-        Returns
-        -------
-        prim_key : int
-            The dataset ID of the new row relating to this entry (else None)
-        execution_id : int
-            The execution ID associated with the dataset
-        """
+		Returns
+		-------
+		prim_key : int
+			The dataset ID of the new row relating to this entry (else None)
+		execution_id : int
+			The execution ID associated with the dataset
+		"""
 
-        # Set max configuration file length
-        if max_config_length is None:
-            max_config_length = self._DEFAULT_MAX_CONFIG
+		# Set max configuration file length
+		if max_config_length is None:
+			max_config_length = self._DEFAULT_MAX_CONFIG
 
-        # Make sure the owner_type is legal
-        if owner_type is None:
-            if self._owner_type is not None:
-                owner_type = self._owner_type
-            else:
-                owner_type = "user"
-        if owner_type not in self._OWNER_TYPES:
-            raise ValueError(f"{owner_type} is not a valid owner_type")
+		# Make sure the owner_type is legal
+		if owner_type is None:
+			if self._owner_type is not None:
+				owner_type = self._owner_type
+			else:
+				owner_type = "user"
+		if owner_type not in self._OWNER_TYPES:
+			raise ValueError(f"{owner_type} is not a valid owner_type")
 
-        # Establish the dataset owner
-        if owner is None:
-            if self._owner is not None:
-                owner = self._owner
-            else:
-                owner = self._uid
-        if owner_type == "production":
-            owner = "production"
+		# Establish the dataset owner
+		if owner is None:
+			if self._owner is not None:
+				owner = self._owner
+			else:
+				owner = self._uid
+		if owner_type == "production":
+			owner = "production"
 
-        # Checks for production datasets
-        if owner_type == "production":
-            if is_overwritable:
-                raise ValueError("Cannot overwrite production entries")
-            if version_suffix is not None:
-                raise ValueError("Production entries can't have version suffix")
-            if self._schema != "production":
-                raise ValueError(
-                    "Only the production schema can handle owner_type='production'"
-                )
-        else:
-            if self._schema == "production":
-                raise ValueError(
-                    "Only the production schema can handle owner_type='production'"
-                )
+		# Checks for production datasets
+		if owner_type == "production":
+			if is_overwritable:
+				raise ValueError("Cannot overwrite production entries")
+			if version_suffix is not None:
+				raise ValueError("Production entries can't have version suffix")
+			if self._schema != "production":
+				raise ValueError(
+					"Only the production schema can handle owner_type='production'"
+				)
+		else:
+			if self._schema == "production":
+				raise ValueError(
+					"Only the production schema can handle owner_type='production'"
+				)
 
-        # If `name` not passed, automatically generate a name from the relative path
-        if name is None:
-            name = _name_from_relpath(relative_path)
+		# If `name` not passed, automatically generate a name from the relative path
+		if name is None:
+			name = _name_from_relpath(relative_path)
 
-        # Look for previous entries. Fail if not overwritable
-        dataset_table = self._get_table_metadata("dataset")
-        previous_dataset = self._find_previous(
-            dataset_table,
-            relative_path=relative_path,
-            owner=owner,
-            owner_type=owner_type,
-        )
+		# Look for previous entries. Fail if not overwritable
+		dataset_table = self._get_table_metadata("dataset")
+		previous_dataset = self._find_entry(
+			relative_path=relative_path,
+			owner=owner,
+			owner_type=owner_type,
+		)
 
-        if previous_dataset is not None:
-            if not previous_dataset.is_overwritable:
-                print(f"Dataset {relative_path} exists, and is not overwritable")
-                return None
+		if previous_dataset is not None:
+			if not previous_dataset.is_overwritable:
+				print(f"Dataset {relative_path} exists, and is not overwritable")
+				return None
 
-        # Deal with version string (non-special case)
-        if version not in ["major", "minor", "patch"]:
-            v_fields = _parse_version_string(version)
-            version_string = version
-        else:
-            # Generate new version fields based on previous entries
-            # with the same name field and same suffix (i.e., bump)
-            v_fields = _bump_version(
-                name, version, version_suffix, dataset_table, self._engine
-            )
-            version_string = (
-                f"{v_fields['major']}.{v_fields['minor']}.{v_fields['patch']}"
-            )
+		# Deal with version string (non-special case)
+		if version not in ["major", "minor", "patch"]:
+			v_fields = _parse_version_string(version)
+			version_string = version
+		else:
+			# Generate new version fields based on previous entries
+			# with the same name field and same suffix (i.e., bump)
+			v_fields = _bump_version(
+				name, version, version_suffix, dataset_table, self._engine
+			)
+			version_string = (
+				f"{v_fields['major']}.{v_fields['minor']}.{v_fields['patch']}"
+			)
 
-        # If no execution_id is supplied, create a minimal entry
-        if execution_id is None:
-            if execution_name is None:
-                execution_name = f"for_dataset_{name}-{version_string}"
-                if version_suffix:
-                    execution_name = f"{execution_name}-{version_suffix}"
-            if execution_description is None:
-                execution_description = "Fabricated execution for dataset"
-            execution_id = self.execution_table.register(
-                execution_name,
-                description=execution_description,
-                execution_start=execution_start,
-                locale=execution_locale,
-                configuration=execution_configuration,
-                input_datasets=input_datasets,
-                input_production_datasets=input_production_datasets,
-            )
+		# If no execution_id is supplied, create a minimal entry
+		if execution_id is None:
+			if execution_name is None:
+				execution_name = f"for_dataset_{name}-{version_string}"
+				if version_suffix:
+					execution_name = f"{execution_name}-{version_suffix}"
+			if execution_description is None:
+				execution_description = "Fabricated execution for dataset"
+			execution_id = self.execution_table.register(
+				execution_name,
+				description=execution_description,
+				execution_start=execution_start,
+				locale=execution_locale,
+				configuration=execution_configuration,
+				input_datasets=input_datasets,
+				input_production_datasets=input_production_datasets,
+			)
 
-        # Pull the dataset properties together
-        values = {"name": name, "relative_path": relative_path}
-        values["version_major"] = v_fields["major"]
-        values["version_minor"] = v_fields["minor"]
-        values["version_patch"] = v_fields["patch"]
-        values["version_string"] = version_string
-        if version_suffix:
-            values["version_suffix"] = version_suffix
-        if description:
-            values["description"] = description
-        if execution_id:
-            values["execution_id"] = execution_id
-        if access_API:
-            values["access_API"] = access_API
-        if access_API_configuration:
-            values["access_API_configuration"] = _read_configuration_file(
-                access_API_configuration, max_config_length
-            )
-        values["is_overwritable"] = is_overwritable
-        values["is_overwritten"] = False
-        values["is_external_link"] = False
-        values["is_archived"] = False
-        values["register_date"] = datetime.now()
-        values["owner_type"] = owner_type
-        values["owner"] = owner
-        values["creator_uid"] = self._uid
-        values["register_root_dir"] = self._root_dir
+		# Pull the dataset properties together
+		values = {"name": name, "relative_path": relative_path}
+		values["version_major"] = v_fields["major"]
+		values["version_minor"] = v_fields["minor"]
+		values["version_patch"] = v_fields["patch"]
+		values["version_string"] = version_string
+		if version_suffix:
+			values["version_suffix"] = version_suffix
+		if description:
+			values["description"] = description
+		if execution_id:
+			values["execution_id"] = execution_id
+		if access_API:
+			values["access_API"] = access_API
+		if access_API_configuration:
+			values["access_API_configuration"] = _read_configuration_file(
+				access_API_configuration, max_config_length
+			)
+		values["is_overwritable"] = is_overwritable
+		values["is_overwritten"] = False
+		values["is_external_link"] = False
+		values["is_archived"] = False
+		values["register_date"] = datetime.now()
+		values["owner_type"] = owner_type
+		values["owner"] = owner
+		values["creator_uid"] = self._uid
+		values["register_root_dir"] = self._root_dir
 
-        # We tentatively start with an "invalid" dataset in the database. This
-        # will be upgraded to valid if the data copying (if any) was successful.
-        values["status"] = 0
+		# We tentatively start with an "invalid" dataset in the database. This
+		# will be upgraded to valid if the data copying (if any) was successful.
+		values["status"] = 0
 
-        # Create a new row in the data registry database.
-        with self._engine.connect() as conn:
-            prim_key = add_table_row(conn, dataset_table, values, commit=False)
+		# Create a new row in the data registry database.
+		with self._engine.connect() as conn:
+			prim_key = add_table_row(conn, dataset_table, values, commit=False)
 
-            if previous_dataset is not None:
-                # Update previous rows, setting is_overwritten to True
-                update_stmt = (
-                    update(dataset_table)
-                    .where(dataset_table.c.dataset_id == previous_dataset.dataset_id)
-                    .values(is_overwritten=True)
-                )
-                conn.execute(update_stmt)
-            conn.commit()
+			if previous_dataset is not None:
+				# Update previous rows, setting is_overwritten to True
+				update_stmt = (
+					update(dataset_table)
+					.where(dataset_table.c.dataset_id == previous_dataset.dataset_id)
+					.values(is_overwritten=True)
+				)
+				conn.execute(update_stmt)
+			conn.commit()
 
-        # Get dataset characteristics; copy to `root_dir` if requested
-        if not is_dummy:
-            (
-                dataset_organization,
-                num_files,
-                total_size,
-                ds_creation_date,
-            ) = self._handle_data(
-                relative_path, old_location, owner, owner_type, verbose
-            )
-            valid_status = 1
-        else:
-            dataset_organization = "dummy"
-            num_files = 0
-            total_size = 0
-            ds_creation_date = None
-            valid_status = 0
+		# Get dataset characteristics; copy to `root_dir` if requested
+		if not is_dummy:
+			(
+				dataset_organization,
+				num_files,
+				total_size,
+				ds_creation_date,
+			) = self._handle_data(
+				relative_path, old_location, owner, owner_type, verbose
+			)
+			valid_status = 1
+		else:
+			dataset_organization = "dummy"
+			num_files = 0
+			total_size = 0
+			ds_creation_date = None
+			valid_status = 0
 
-        # Case where use is overwriting the dateset `creation_date`
-        if creation_date:
-            ds_creation_date = creation_date
+		# Case where use is overwriting the dateset `creation_date`
+		if creation_date:
+			ds_creation_date = creation_date
 
-        # Copy was successful, update the entry with dataset metadata
-        with self._engine.connect() as conn:
-            update_stmt = (
-                update(dataset_table)
-                .where(dataset_table.c.dataset_id == prim_key)
-                .values(
-                    data_org=dataset_organization,
-                    nfiles=num_files,
-                    total_disk_space=total_size / 1024 / 1024,
-                    creation_date=ds_creation_date,
-                    status=set_dataset_status(values["status"], valid=True),
-                )
-            )
-            conn.execute(update_stmt)
-            conn.commit()
+		# Copy was successful, update the entry with dataset metadata
+		with self._engine.connect() as conn:
+			update_stmt = (
+				update(dataset_table)
+				.where(dataset_table.c.dataset_id == prim_key)
+				.values(
+					data_org=dataset_organization,
+					nfiles=num_files,
+					total_disk_space=total_size / 1024 / 1024,
+					creation_date=ds_creation_date,
+					status=set_dataset_status(values["status"], valid=True),
+				)
+			)
+			conn.execute(update_stmt)
+			conn.commit()
 
-        return prim_key, execution_id
+		return prim_key, execution_id
 
-    def _handle_data(self, relative_path, old_location, owner, owner_type, verbose):
-        """
-        Find characteristics of dataset (i.e., is it a file or directory, how
-        many files and total disk space of the dataset).
+	def _handle_data(self, relative_path, old_location, owner, owner_type, verbose):
+		"""
+		Find characteristics of dataset (i.e., is it a file or directory, how
+		many files and total disk space of the dataset).
 
-        If old_location is not None, copy the dataset files and directories
-        into the data registry.
+		If old_location is not None, copy the dataset files and directories
+		into the data registry.
 
-        Parameters
-        ----------
-        relative_path : str
-            Relative path of dataset in the data registry
-        old_location : str
-            Location of data (if not already in the data registry root)
-            Data will be copied from this location
-        owner : str
-            Owner of the dataset
-        owner_type : str
-            Owner type of the dataset
-        verbose : bool
-            True for extra output
+		Parameters
+		----------
+		relative_path : str
+			Relative path of dataset in the data registry
+		old_location : str
+			Location of data (if not already in the data registry root)
+			Data will be copied from this location
+		owner : str
+			Owner of the dataset
+		owner_type : str
+			Owner type of the dataset
+		verbose : bool
+			True for extra output
 
-        Returns
-        -------
-        dataset_organization : str
-            "file", "directory", or "dummy"
-        num_files : int
-            Total number of files making up dataset
-        total_size : float
-            Total disk space of dataset in bytes
-        ds_creation_date : datetime
-            When file or directory was created
-        """
+		Returns
+		-------
+		dataset_organization : str
+			"file", "directory", or "dummy"
+		num_files : int
+			Total number of files making up dataset
+		total_size : float
+			Total disk space of dataset in bytes
+		ds_creation_date : datetime
+			When file or directory was created
+		"""
 
-        # Get destination directory in data registry.
-        dest = _form_dataset_path(
-            owner_type,
-            owner,
-            relative_path,
-            schema=self._schema,
-            root_dir=self._root_dir,
-        )
+		# Get destination directory in data registry.
+		dest = _form_dataset_path(
+			owner_type,
+			owner,
+			relative_path,
+			schema=self._schema,
+			root_dir=self._root_dir,
+		)
 
-        # Is the data already on location, or coming from somewhere new?
-        if old_location:
-            loc = old_location
-        else:
-            loc = dest
+		# Is the data already on location, or coming from somewhere new?
+		if old_location:
+			loc = old_location
+		else:
+			loc = dest
 
-        # Get metadata on dataset.
-        if os.path.isfile(loc):
-            dataset_organization = "file"
-        elif os.path.isdir(loc):
-            dataset_organization = "directory"
-        else:
-            raise FileNotFoundError(f"Dataset {loc} not found")
+		# Get metadata on dataset.
+		if os.path.isfile(loc):
+			dataset_organization = "file"
+		elif os.path.isdir(loc):
+			dataset_organization = "directory"
+		else:
+			raise FileNotFoundError(f"Dataset {loc} not found")
 
-        if verbose:
-            tic = time.time()
-            print("Collecting metadata...", end="")
+		if verbose:
+			tic = time.time()
+			print("Collecting metadata...", end="")
 
-        ds_creation_date = datetime.fromtimestamp(os.path.getctime(loc))
+		ds_creation_date = datetime.fromtimestamp(os.path.getctime(loc))
 
-        if dataset_organization == "directory":
-            num_files, total_size = get_directory_info(loc)
-        else:
-            num_files = 1
-            total_size = os.path.getsize(loc)
-        if verbose:
-            print(f"took {time.time()-tic:.2f}s")
+		if dataset_organization == "directory":
+			num_files, total_size = get_directory_info(loc)
+		else:
+			num_files = 1
+			total_size = os.path.getsize(loc)
+		if verbose:
+			print(f"took {time.time()-tic:.2f}s")
 
-        # Copy data into data registry
-        if old_location:
-            if verbose:
-                tic = time.time()
-                print(
-                    f"Copying {num_files} files ({total_size/1024/1024:.2f} Mb)...",
-                    end="",
-                )
-            _copy_data(dataset_organization, old_location, dest)
-            if verbose:
-                print(f"took {time.time()-tic:.2f}")
+		# Copy data into data registry
+		if old_location:
+			if verbose:
+				tic = time.time()
+				print(
+					f"Copying {num_files} files ({total_size/1024/1024:.2f} Mb)...",
+					end="",
+				)
+			_copy_data(dataset_organization, old_location, dest)
+			if verbose:
+				print(f"took {time.time()-tic:.2f}")
 
-        return dataset_organization, num_files, total_size, ds_creation_date
+		return dataset_organization, num_files, total_size, ds_creation_date
 
-    def _find_previous(
-        self,
-        dataset_table,
-        relative_path=None,
-        owner=None,
-        owner_type=None,
-        dataset_id=None,
-    ):
-        """
-        Check to see if a dataset exists already in the registry, and if we are
-        allowed to overwrite it.
+	def _find_entry(
+		self,
+		relative_path=None,
+		owner=None,
+		owner_type=None,
+		dataset_id=None,
+	):
+		"""
+		Find a dataset entry in the database.
 
-        Can search either by `dataset_id`, or a combination of `relative_path`,
-        `owner` and `owner_type`.
+		Can search by either:
+			1) Just `dataset_id`
+			2) A combination of `relative_path`, `owner` and `owner_type`.
 
-        Only one dataset should ever be found.
+		Only one dataset should ever be found.
 
-        Parameters
-        ----------
-        dataset_table : SQLAlchemy Table object
-            Link to the dataset table
-        relative_path : str, optional
-            Relative path to dataset
-        owner : str, optional
-            Owner of the dataset
-        owner_type : str, optional
-        dataset_id : int, optional
+		Parameters
+		----------
+		relative_path : str, optional
+			Relative path to dataset
+		owner : str, optional
+			Owner of the dataset
+		owner_type : str, optional
+		dataset_id : int, optional
 
-        Returns
-        -------
-        r : CursorResult object
-            Searched dataset
-        """
+		Returns
+		-------
+		r : CursorResult object
+			Searched dataset
+		"""
 
-        # Make sure we have all the relavant information
-        if dataset_id is None:
-            if (relative_path is None) or (owner is None) or (owner_type is None):
-                raise ValueError(
-                    "Must pass relative_path, owner and owner_type to _find_previous"
-                )
+		# Make sure we have all the relavant information
+		if dataset_id is None:
+			if (relative_path is None) or (owner is None) or (owner_type is None):
+				raise ValueError(
+					"Must pass relative_path, owner and owner_type to _find_entry"
+				)
 
-        # Search for dataset in the registry.
-        if dataset_id is None:
-            stmt = (
-                select(
-                    dataset_table.c.dataset_id,
-                    dataset_table.c.is_overwritable,
-                    dataset_table.c.status,
-                    dataset_table.c.owner,
-                    dataset_table.c.owner_type,
-                    dataset_table.c.relative_path,
-                )
-                .where(
-                    dataset_table.c.relative_path == relative_path,
-                    dataset_table.c.owner == owner,
-                    dataset_table.c.owner_type == owner_type,
-                )
-                .order_by(dataset_table.c.dataset_id.desc())
-            )
-        else:
-            stmt = (
-                select(
-                    dataset_table.c.dataset_id,
-                    dataset_table.c.is_overwritable,
-                    dataset_table.c.status,
-                    dataset_table.c.owner,
-                    dataset_table.c.owner_type,
-                    dataset_table.c.relative_path,
-                )
-                .where(
-                    dataset_table.c.dataset_id == dataset_id,
-                )
-                .order_by(dataset_table.c.dataset_id.desc())
-            )
+		# Search for dataset in the registry.
+		dataset_table = self._get_table_metadata("dataset")
+		stmt = select(dataset_table)
 
-        with self._engine.connect() as conn:
-            result = conn.execute(stmt)
-            conn.commit()
+		if dataset_id is None:
+			stmt = stmt.where(
+				dataset_table.c.relative_path == relative_path,
+				dataset_table.c.owner == owner,
+				dataset_table.c.owner_type == owner_type,
+			)
+		else:
+			stmt = stmt.where(dataset_table.c.dataset_id == dataset_id)
 
-        # If the datasets are overwritable, log their ID, else return None
-        for r in result:
-            return r
+		with self._engine.connect() as conn:
+			result = conn.execute(stmt)
+			conn.commit()
 
-        return None
+		# Pull out the single result
+		for r in result:
+			return r
+
+		# No results found
+		return None
+
+	def delete(self, dataset_id):
+		"""
+		Delete an dataset entry from the DESC data registry.
+
+		This will also remove the raw data from the root dir, but the dataset
+		entry remains in the registry (now with an updated `status` field).
+
+		Parameters
+		----------
+		dataset_id : int
+			Dataset we want to delete from the registry
+		"""
+
+		# First make sure the given dataset id is in the registry
+		dataset_table = self._get_table_metadata(self.which_table)
+		previous_dataset = self._find_entry(dataset_table, dataset_id=dataset_id)
+
+		# Check dataset exists
+		if previous_dataset is None:
+			raise ValueError(f"Dataset ID {dataset_id} does not exist")
+		# Check dataset is valid
+		if not get_dataset_status(previous_dataset.status, "valid"):
+			raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
+		# Check dataset has not already been deleted
+		if get_dataset_status(previous_dataset.status, "deleted"):
+			raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
+
+		# Update the status of the dataset to deleted
+		with self._engine.connect() as conn:
+			update_stmt = (
+				update(dataset_table)
+				.where(dataset_table.c.dataset_id == dataset_id)
+				.values(
+					status=set_dataset_status(previous_dataset.status, deleted=True),
+					delete_date=datetime.now(),
+					delete_uid=self._uid,
+				)
+			)
+			conn.execute(update_stmt)
+			conn.commit()
+
+		# Delete the physical data in the root_dir
+		if previous_dataset.data_org != "dummy":
+			data_path = _form_dataset_path(
+				previous_dataset.owner_type,
+				previous_dataset.owner,
+				previous_dataset.relative_path,
+				schema=self._schema,
+				root_dir=self._root_dir,
+			)
+			print(f"Deleting data {data_path}")
+			os.remove(data_path)
+
+		print(f"Deleted {dataset_id} from data registry")

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -7,481 +7,470 @@ from sqlalchemy import select, update
 
 from .base_table_class import BaseTable
 from .registrar_util import (
-	_bump_version,
-	_copy_data,
-	_form_dataset_path,
-	_name_from_relpath,
-	_parse_version_string,
-	_read_configuration_file,
-	get_directory_info,
+    _bump_version,
+    _copy_data,
+    _form_dataset_path,
+    _name_from_relpath,
+    _parse_version_string,
+    _read_configuration_file,
+    get_directory_info,
 )
 from .dataset_util import set_dataset_status, get_dataset_status
 
 
 class DatasetTable(BaseTable):
-	def __init__(self, db_connection, root_dir, owner, owner_type, execution_table):
-		super().__init__(db_connection, root_dir, owner, owner_type)
+    def __init__(self, db_connection, root_dir, owner, owner_type, execution_table):
+        super().__init__(db_connection, root_dir, owner, owner_type)
 
-		self.execution_table = execution_table
-		self.which_table = "dataset"
+        self.execution_table = execution_table
+        self.which_table = "dataset"
 
-	def register(
-		self,
-		relative_path,
-		version,
-		version_suffix=None,
-		name=None,
-		creation_date=None,
-		description=None,
-		execution_id=None,
-		access_API=None,
-		access_API_configuration=None,
-		is_overwritable=False,
-		old_location=None,
-		copy=True,
-		is_dummy=False,
-		verbose=False,
-		owner=None,
-		owner_type=None,
-		execution_name=None,
-		execution_description=None,
-		execution_start=None,
-		execution_locale=None,
-		execution_configuration=None,
-		input_datasets=[],
-		input_production_datasets=[],
-		max_config_length=None,
-	):
-		"""
-		Create a new dataset entry in the DESC data registry.
+    def register(
+        self,
+        relative_path,
+        version,
+        version_suffix=None,
+        name=None,
+        creation_date=None,
+        description=None,
+        execution_id=None,
+        access_API=None,
+        access_API_configuration=None,
+        is_overwritable=False,
+        old_location=None,
+        copy=True,
+        is_dummy=False,
+        verbose=False,
+        owner=None,
+        owner_type=None,
+        execution_name=None,
+        execution_description=None,
+        execution_start=None,
+        execution_locale=None,
+        execution_configuration=None,
+        input_datasets=[],
+        input_production_datasets=[],
+        max_config_length=None,
+    ):
+        """
+        Create a new dataset entry in the DESC data registry.
 
-		Any args marked with '**' share their name with the associated column
-		in the registry schema. Descriptions of what these columns are can be
-		found in `schema.yaml` or the documentation.
+        Any args marked with '**' share their name with the associated column
+        in the registry schema. Descriptions of what these columns are can be
+        found in `schema.yaml` or the documentation.
 
-		First, the dataset entry is created in the database. If success, the
-		data is then copied (if `old_location` was provided). Only if both
-		steps are successful will there be "valid" status entry in the
-		registry.
+        First, the dataset entry is created in the database. If success, the
+        data is then copied (if `old_location` was provided). Only if both
+        steps are successful will there be "valid" status entry in the
+        registry.
 
-		Parameters
-		----------
-		relative_path** : str
-		version** : str
-		version_suffix** : str, optional
-		name** : str, optional
-		creation_date** : datetime, optional
-		description** : str, optional
-		execution_id** : int, optional
-		access_API** : str, optional
-		is_overwritable** : bool, optional
-		old_location : str, optional
-			Absolute location of dataset to copy into the data registry.
+        Parameters
+        ----------
+        relative_path** : str
+        version** : str
+        version_suffix** : str, optional
+        name** : str, optional
+        creation_date** : datetime, optional
+        description** : str, optional
+        execution_id** : int, optional
+        access_API** : str, optional
+        is_overwritable** : bool, optional
+        old_location : str, optional
+            Absolute location of dataset to copy into the data registry.
 
-			If None, dataset should already be at correct relative_path within
-			the data registry.
-		copy : bool, optional
-			True to copy data from ``old_location`` into the data registry
-			(default behaviour).
-			False to create a symlink.
-		is_dummy : bool, optional
-			True for "dummy" datasets (no data is copied, for testing purposes
-			only)
-		verbose : bool, optional
-			Provide some additional output information
-		owner** : str, optional
-		owner_type** : str, optional
-		execution_name** : str, optional
-		execution_description** : str, optional
-		execution_start** : datetime, optional
-		execution_locale** : str, optional
-		execution_configuration** : str, optional
-		input_datasets : list, optional
-			List of dataset ids that were the input to this execution
-		input_production_datasets : list, optional
-			List of production dataset ids that were the input to this execution
-		max_config_length : int, optional
-			Maxiumum number of lines to read from a configuration file
+            If None, dataset should already be at correct relative_path within
+            the data registry.
+        copy : bool, optional
+            True to copy data from ``old_location`` into the data registry
+            (default behaviour).
+            False to create a symlink.
+        is_dummy : bool, optional
+            True for "dummy" datasets (no data is copied, for testing purposes
+            only)
+        verbose : bool, optional
+            Provide some additional output information
+        owner** : str, optional
+        owner_type** : str, optional
+        execution_name** : str, optional
+        execution_description** : str, optional
+        execution_start** : datetime, optional
+        execution_locale** : str, optional
+        execution_configuration** : str, optional
+        input_datasets : list, optional
+            List of dataset ids that were the input to this execution
+        input_production_datasets : list, optional
+            List of production dataset ids that were the input to this execution
+        max_config_length : int, optional
+            Maxiumum number of lines to read from a configuration file
 
-		Returns
-		-------
-		prim_key : int
-			The dataset ID of the new row relating to this entry (else None)
-		execution_id : int
-			The execution ID associated with the dataset
-		"""
+        Returns
+        -------
+        prim_key : int
+            The dataset ID of the new row relating to this entry (else None)
+        execution_id : int
+            The execution ID associated with the dataset
+        """
 
-		# Set max configuration file length
-		if max_config_length is None:
-			max_config_length = self._DEFAULT_MAX_CONFIG
+        # Set max configuration file length
+        if max_config_length is None:
+            max_config_length = self._DEFAULT_MAX_CONFIG
 
-		# Make sure the owner_type is legal
-		if owner_type is None:
-			if self._owner_type is not None:
-				owner_type = self._owner_type
-			else:
-				owner_type = "user"
-		if owner_type not in self._OWNER_TYPES:
-			raise ValueError(f"{owner_type} is not a valid owner_type")
+        # Make sure the owner_type is legal
+        if owner_type is None:
+            if self._owner_type is not None:
+                owner_type = self._owner_type
+            else:
+                owner_type = "user"
+        if owner_type not in self._OWNER_TYPES:
+            raise ValueError(f"{owner_type} is not a valid owner_type")
 
-		# Establish the dataset owner
-		if owner is None:
-			if self._owner is not None:
-				owner = self._owner
-			else:
-				owner = self._uid
-		if owner_type == "production":
-			owner = "production"
+        # Establish the dataset owner
+        if owner is None:
+            if self._owner is not None:
+                owner = self._owner
+            else:
+                owner = self._uid
+        if owner_type == "production":
+            owner = "production"
 
-		# Checks for production datasets
-		if owner_type == "production":
-			if is_overwritable:
-				raise ValueError("Cannot overwrite production entries")
-			if version_suffix is not None:
-				raise ValueError("Production entries can't have version suffix")
-			if self._schema != "production":
-				raise ValueError(
-					"Only the production schema can handle owner_type='production'"
-				)
-		else:
-			if self._schema == "production":
-				raise ValueError(
-					"Only the production schema can handle owner_type='production'"
-				)
+        # Checks for production datasets
+        if owner_type == "production":
+            if is_overwritable:
+                raise ValueError("Cannot overwrite production entries")
+            if version_suffix is not None:
+                raise ValueError("Production entries can't have version suffix")
+            if self._schema != "production":
+                raise ValueError(
+                    "Only the production schema can handle owner_type='production'"
+                )
+        else:
+            if self._schema == "production":
+                raise ValueError(
+                    "Only the production schema can handle owner_type='production'"
+                )
 
-		# If `name` not passed, automatically generate a name from the relative path
-		if name is None:
-			name = _name_from_relpath(relative_path)
+        # If `name` not passed, automatically generate a name from the relative path
+        if name is None:
+            name = _name_from_relpath(relative_path)
 
-		# Look for previous entries. Fail if not overwritable
-		dataset_table = self._get_table_metadata("dataset")
-		previous_dataset = self._find_entry(
-			relative_path=relative_path,
-			owner=owner,
-			owner_type=owner_type,
-		)
+        # Look for previous entries. Fail if not overwritable
+        dataset_table = self._get_table_metadata("dataset")
+        previous_dataset_id, previous_dataset_overwritable = self._find_previous(
+            relative_path,
+            owner,
+            owner_type,
+        )
 
-		if previous_dataset is not None:
-			if not previous_dataset.is_overwritable:
-				print(f"Dataset {relative_path} exists, and is not overwritable")
-				return None
+        if previous_dataset_id is not None:
+            if not previous_dataset_overwritable:
+                print(f"Dataset {relative_path} exists, and is not overwritable")
+                return None
 
-		# Deal with version string (non-special case)
-		if version not in ["major", "minor", "patch"]:
-			v_fields = _parse_version_string(version)
-			version_string = version
-		else:
-			# Generate new version fields based on previous entries
-			# with the same name field and same suffix (i.e., bump)
-			v_fields = _bump_version(
-				name, version, version_suffix, dataset_table, self._engine
-			)
-			version_string = (
-				f"{v_fields['major']}.{v_fields['minor']}.{v_fields['patch']}"
-			)
+        # Deal with version string (non-special case)
+        if version not in ["major", "minor", "patch"]:
+            v_fields = _parse_version_string(version)
+            version_string = version
+        else:
+            # Generate new version fields based on previous entries
+            # with the same name field and same suffix (i.e., bump)
+            v_fields = _bump_version(
+                name, version, version_suffix, dataset_table, self._engine
+            )
+            version_string = (
+                f"{v_fields['major']}.{v_fields['minor']}.{v_fields['patch']}"
+            )
 
-		# If no execution_id is supplied, create a minimal entry
-		if execution_id is None:
-			if execution_name is None:
-				execution_name = f"for_dataset_{name}-{version_string}"
-				if version_suffix:
-					execution_name = f"{execution_name}-{version_suffix}"
-			if execution_description is None:
-				execution_description = "Fabricated execution for dataset"
-			execution_id = self.execution_table.register(
-				execution_name,
-				description=execution_description,
-				execution_start=execution_start,
-				locale=execution_locale,
-				configuration=execution_configuration,
-				input_datasets=input_datasets,
-				input_production_datasets=input_production_datasets,
-			)
+        # If no execution_id is supplied, create a minimal entry
+        if execution_id is None:
+            if execution_name is None:
+                execution_name = f"for_dataset_{name}-{version_string}"
+                if version_suffix:
+                    execution_name = f"{execution_name}-{version_suffix}"
+            if execution_description is None:
+                execution_description = "Fabricated execution for dataset"
+            execution_id = self.execution_table.register(
+                execution_name,
+                description=execution_description,
+                execution_start=execution_start,
+                locale=execution_locale,
+                configuration=execution_configuration,
+                input_datasets=input_datasets,
+                input_production_datasets=input_production_datasets,
+            )
 
-		# Pull the dataset properties together
-		values = {"name": name, "relative_path": relative_path}
-		values["version_major"] = v_fields["major"]
-		values["version_minor"] = v_fields["minor"]
-		values["version_patch"] = v_fields["patch"]
-		values["version_string"] = version_string
-		if version_suffix:
-			values["version_suffix"] = version_suffix
-		if description:
-			values["description"] = description
-		if execution_id:
-			values["execution_id"] = execution_id
-		if access_API:
-			values["access_API"] = access_API
-		if access_API_configuration:
-			values["access_API_configuration"] = _read_configuration_file(
-				access_API_configuration, max_config_length
-			)
-		values["is_overwritable"] = is_overwritable
-		values["is_overwritten"] = False
-		values["is_external_link"] = False
-		values["is_archived"] = False
-		values["register_date"] = datetime.now()
-		values["owner_type"] = owner_type
-		values["owner"] = owner
-		values["creator_uid"] = self._uid
-		values["register_root_dir"] = self._root_dir
+        # Pull the dataset properties together
+        values = {"name": name, "relative_path": relative_path}
+        values["version_major"] = v_fields["major"]
+        values["version_minor"] = v_fields["minor"]
+        values["version_patch"] = v_fields["patch"]
+        values["version_string"] = version_string
+        if version_suffix:
+            values["version_suffix"] = version_suffix
+        if description:
+            values["description"] = description
+        if execution_id:
+            values["execution_id"] = execution_id
+        if access_API:
+            values["access_API"] = access_API
+        if access_API_configuration:
+            values["access_API_configuration"] = _read_configuration_file(
+                access_API_configuration, max_config_length
+            )
+        values["is_overwritable"] = is_overwritable
+        values["is_overwritten"] = False
+        values["is_external_link"] = False
+        values["is_archived"] = False
+        values["register_date"] = datetime.now()
+        values["owner_type"] = owner_type
+        values["owner"] = owner
+        values["creator_uid"] = self._uid
+        values["register_root_dir"] = self._root_dir
 
-		# We tentatively start with an "invalid" dataset in the database. This
-		# will be upgraded to valid if the data copying (if any) was successful.
-		values["status"] = 0
+        # We tentatively start with an "invalid" dataset in the database. This
+        # will be upgraded to valid if the data copying (if any) was successful.
+        values["status"] = 0
 
-		# Create a new row in the data registry database.
-		with self._engine.connect() as conn:
-			prim_key = add_table_row(conn, dataset_table, values, commit=False)
+        # Create a new row in the data registry database.
+        with self._engine.connect() as conn:
+            prim_key = add_table_row(conn, dataset_table, values, commit=False)
 
-			if previous_dataset is not None:
-				# Update previous rows, setting is_overwritten to True
-				update_stmt = (
-					update(dataset_table)
-					.where(dataset_table.c.dataset_id == previous_dataset.dataset_id)
-					.values(is_overwritten=True)
-				)
-				conn.execute(update_stmt)
-			conn.commit()
+            if previous_dataset_id is not None:
+                # Update previous rows, setting is_overwritten to True
+                update_stmt = (
+                    update(dataset_table)
+                    .where(dataset_table.c.dataset_id == previous_dataset_id)
+                    .values(is_overwritten=True)
+                )
+                conn.execute(update_stmt)
+            conn.commit()
 
-		# Get dataset characteristics; copy to `root_dir` if requested
-		if not is_dummy:
-			(
-				dataset_organization,
-				num_files,
-				total_size,
-				ds_creation_date,
-			) = self._handle_data(
-				relative_path, old_location, owner, owner_type, verbose
-			)
-			valid_status = 1
-		else:
-			dataset_organization = "dummy"
-			num_files = 0
-			total_size = 0
-			ds_creation_date = None
-			valid_status = 0
+        # Get dataset characteristics; copy to `root_dir` if requested
+        if not is_dummy:
+            (
+                dataset_organization,
+                num_files,
+                total_size,
+                ds_creation_date,
+            ) = self._handle_data(
+                relative_path, old_location, owner, owner_type, verbose
+            )
+            valid_status = 1
+        else:
+            dataset_organization = "dummy"
+            num_files = 0
+            total_size = 0
+            ds_creation_date = None
+            valid_status = 0
 
-		# Case where use is overwriting the dateset `creation_date`
-		if creation_date:
-			ds_creation_date = creation_date
+        # Case where use is overwriting the dateset `creation_date`
+        if creation_date:
+            ds_creation_date = creation_date
 
-		# Copy was successful, update the entry with dataset metadata
-		with self._engine.connect() as conn:
-			update_stmt = (
-				update(dataset_table)
-				.where(dataset_table.c.dataset_id == prim_key)
-				.values(
-					data_org=dataset_organization,
-					nfiles=num_files,
-					total_disk_space=total_size / 1024 / 1024,
-					creation_date=ds_creation_date,
-					status=set_dataset_status(values["status"], valid=True),
-				)
-			)
-			conn.execute(update_stmt)
-			conn.commit()
+        # Copy was successful, update the entry with dataset metadata
+        with self._engine.connect() as conn:
+            update_stmt = (
+                update(dataset_table)
+                .where(dataset_table.c.dataset_id == prim_key)
+                .values(
+                    data_org=dataset_organization,
+                    nfiles=num_files,
+                    total_disk_space=total_size / 1024 / 1024,
+                    creation_date=ds_creation_date,
+                    status=set_dataset_status(values["status"], valid=True),
+                )
+            )
+            conn.execute(update_stmt)
+            conn.commit()
 
-		return prim_key, execution_id
+        return prim_key, execution_id
 
-	def _handle_data(self, relative_path, old_location, owner, owner_type, verbose):
-		"""
-		Find characteristics of dataset (i.e., is it a file or directory, how
-		many files and total disk space of the dataset).
+    def _handle_data(self, relative_path, old_location, owner, owner_type, verbose):
+        """
+        Find characteristics of dataset (i.e., is it a file or directory, how
+        many files and total disk space of the dataset).
 
-		If old_location is not None, copy the dataset files and directories
-		into the data registry.
+        If old_location is not None, copy the dataset files and directories
+        into the data registry.
 
-		Parameters
-		----------
-		relative_path : str
-			Relative path of dataset in the data registry
-		old_location : str
-			Location of data (if not already in the data registry root)
-			Data will be copied from this location
-		owner : str
-			Owner of the dataset
-		owner_type : str
-			Owner type of the dataset
-		verbose : bool
-			True for extra output
+        Parameters
+        ----------
+        relative_path : str
+            Relative path of dataset in the data registry
+        old_location : str
+            Location of data (if not already in the data registry root)
+            Data will be copied from this location
+        owner : str
+            Owner of the dataset
+        owner_type : str
+            Owner type of the dataset
+        verbose : bool
+            True for extra output
 
-		Returns
-		-------
-		dataset_organization : str
-			"file", "directory", or "dummy"
-		num_files : int
-			Total number of files making up dataset
-		total_size : float
-			Total disk space of dataset in bytes
-		ds_creation_date : datetime
-			When file or directory was created
-		"""
+        Returns
+        -------
+        dataset_organization : str
+            "file", "directory", or "dummy"
+        num_files : int
+            Total number of files making up dataset
+        total_size : float
+            Total disk space of dataset in bytes
+        ds_creation_date : datetime
+            When file or directory was created
+        """
 
-		# Get destination directory in data registry.
-		dest = _form_dataset_path(
-			owner_type,
-			owner,
-			relative_path,
-			schema=self._schema,
-			root_dir=self._root_dir,
-		)
+        # Get destination directory in data registry.
+        dest = _form_dataset_path(
+            owner_type,
+            owner,
+            relative_path,
+            schema=self._schema,
+            root_dir=self._root_dir,
+        )
 
-		# Is the data already on location, or coming from somewhere new?
-		if old_location:
-			loc = old_location
-		else:
-			loc = dest
+        # Is the data already on location, or coming from somewhere new?
+        if old_location:
+            loc = old_location
+        else:
+            loc = dest
 
-		# Get metadata on dataset.
-		if os.path.isfile(loc):
-			dataset_organization = "file"
-		elif os.path.isdir(loc):
-			dataset_organization = "directory"
-		else:
-			raise FileNotFoundError(f"Dataset {loc} not found")
+        # Get metadata on dataset.
+        if os.path.isfile(loc):
+            dataset_organization = "file"
+        elif os.path.isdir(loc):
+            dataset_organization = "directory"
+        else:
+            raise FileNotFoundError(f"Dataset {loc} not found")
 
-		if verbose:
-			tic = time.time()
-			print("Collecting metadata...", end="")
+        if verbose:
+            tic = time.time()
+            print("Collecting metadata...", end="")
 
-		ds_creation_date = datetime.fromtimestamp(os.path.getctime(loc))
+        ds_creation_date = datetime.fromtimestamp(os.path.getctime(loc))
 
-		if dataset_organization == "directory":
-			num_files, total_size = get_directory_info(loc)
-		else:
-			num_files = 1
-			total_size = os.path.getsize(loc)
-		if verbose:
-			print(f"took {time.time()-tic:.2f}s")
+        if dataset_organization == "directory":
+            num_files, total_size = get_directory_info(loc)
+        else:
+            num_files = 1
+            total_size = os.path.getsize(loc)
+        if verbose:
+            print(f"took {time.time()-tic:.2f}s")
 
-		# Copy data into data registry
-		if old_location:
-			if verbose:
-				tic = time.time()
-				print(
-					f"Copying {num_files} files ({total_size/1024/1024:.2f} Mb)...",
-					end="",
-				)
-			_copy_data(dataset_organization, old_location, dest)
-			if verbose:
-				print(f"took {time.time()-tic:.2f}")
+        # Copy data into data registry
+        if old_location:
+            if verbose:
+                tic = time.time()
+                print(
+                    f"Copying {num_files} files ({total_size/1024/1024:.2f} Mb)...",
+                    end="",
+                )
+            _copy_data(dataset_organization, old_location, dest)
+            if verbose:
+                print(f"took {time.time()-tic:.2f}")
 
-		return dataset_organization, num_files, total_size, ds_creation_date
+        return dataset_organization, num_files, total_size, ds_creation_date
 
-	def _find_entry(
-		self,
-		relative_path=None,
-		owner=None,
-		owner_type=None,
-		dataset_id=None,
-	):
-		"""
-		Find a dataset entry in the database.
+    def _find_previous(self, relative_path, owner, owner_type):
+        """
+        Find a dataset(s) based on their combination of `relative_path`,
+        `owner`, `owner_type`.
 
-		Can search by either:
-			1) Just `dataset_id`
-			2) A combination of `relative_path`, `owner` and `owner_type`.
+        Looking to see if an entry exists, so we can check if it is
+        overwritable. If multiple datasets are found, only the latest (i.e.,
+        that with `is_overwritten=False`) is of interest.
 
-		Only one dataset should ever be found.
+        Parameters
+        ----------
+        relative_path : str
+            Relative path to dataset
+        owner : str
+            Owner of the dataset
+        owner_type : str
+            Owner type of the dataset
 
-		Parameters
-		----------
-		relative_path : str, optional
-			Relative path to dataset
-		owner : str, optional
-			Owner of the dataset
-		owner_type : str, optional
-		dataset_id : int, optional
+        Returns
+        -------
+        dataset_id : bool
+            Dataset ID of dataset with the path combination
+        dataset_is_overwritable : bool
+            True if found dataset can be overwritten
+        """
 
-		Returns
-		-------
-		r : CursorResult object
-			Searched dataset
-		"""
+        # Search for dataset in the registry.
+        dataset_table = self._get_table_metadata("dataset")
+        stmt = select(dataset_table)
 
-		# Make sure we have all the relavant information
-		if dataset_id is None:
-			if (relative_path is None) or (owner is None) or (owner_type is None):
-				raise ValueError(
-					"Must pass relative_path, owner and owner_type to _find_entry"
-				)
+        stmt = stmt.where(
+            dataset_table.c.relative_path == relative_path,
+            dataset_table.c.owner == owner,
+            dataset_table.c.owner_type == owner_type,
+        )
 
-		# Search for dataset in the registry.
-		dataset_table = self._get_table_metadata("dataset")
-		stmt = select(dataset_table)
+        with self._engine.connect() as conn:
+            result = conn.execute(stmt)
+            conn.commit()
 
-		if dataset_id is None:
-			stmt = stmt.where(
-				dataset_table.c.relative_path == relative_path,
-				dataset_table.c.owner == owner,
-				dataset_table.c.owner_type == owner_type,
-			)
-		else:
-			stmt = stmt.where(dataset_table.c.dataset_id == dataset_id)
+        # Pull out the single result
+        dataset_id = None
+        dataset_is_overwritable = None
+        for r in result:
+            if not r.is_overwritten:
+                dataset_is_overwritable = r.is_overwritable
+                dataset_id = r.dataset_id
+                break
 
-		with self._engine.connect() as conn:
-			result = conn.execute(stmt)
-			conn.commit()
+        return dataset_id, dataset_is_overwritable
 
-		# Pull out the single result
-		for r in result:
-			return r
+    def delete(self, dataset_id):
+        """
+        Delete an dataset entry from the DESC data registry.
 
-		# No results found
-		return None
+        This will also remove the raw data from the root dir, but the dataset
+        entry remains in the registry (now with an updated `status` field).
 
-	def delete(self, dataset_id):
-		"""
-		Delete an dataset entry from the DESC data registry.
+        Parameters
+        ----------
+        dataset_id : int
+            Dataset we want to delete from the registry
+        """
 
-		This will also remove the raw data from the root dir, but the dataset
-		entry remains in the registry (now with an updated `status` field).
+        # First make sure the given dataset id is in the registry
+        dataset_table = self._get_table_metadata(self.which_table)
+        previous_dataset = self.find_entry(dataset_id)
 
-		Parameters
-		----------
-		dataset_id : int
-			Dataset we want to delete from the registry
-		"""
+        # Check dataset exists
+        if previous_dataset is None:
+            raise ValueError(f"Dataset ID {dataset_id} does not exist")
+        # Check dataset is valid
+        if not get_dataset_status(previous_dataset.status, "valid"):
+            raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
+        # Check dataset has not already been deleted
+        if get_dataset_status(previous_dataset.status, "deleted"):
+            raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
 
-		# First make sure the given dataset id is in the registry
-		dataset_table = self._get_table_metadata(self.which_table)
-		previous_dataset = self._find_entry(dataset_table, dataset_id=dataset_id)
+        # Update the status of the dataset to deleted
+        with self._engine.connect() as conn:
+            update_stmt = (
+                update(dataset_table)
+                .where(dataset_table.c.dataset_id == dataset_id)
+                .values(
+                    status=set_dataset_status(previous_dataset.status, deleted=True),
+                    delete_date=datetime.now(),
+                    delete_uid=self._uid,
+                )
+            )
+            conn.execute(update_stmt)
+            conn.commit()
 
-		# Check dataset exists
-		if previous_dataset is None:
-			raise ValueError(f"Dataset ID {dataset_id} does not exist")
-		# Check dataset is valid
-		if not get_dataset_status(previous_dataset.status, "valid"):
-			raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
-		# Check dataset has not already been deleted
-		if get_dataset_status(previous_dataset.status, "deleted"):
-			raise ValueError(f"Dataset ID {dataset_id} does not have a valid status")
+        # Delete the physical data in the root_dir
+        if previous_dataset.data_org != "dummy":
+            data_path = _form_dataset_path(
+                previous_dataset.owner_type,
+                previous_dataset.owner,
+                previous_dataset.relative_path,
+                schema=self._schema,
+                root_dir=self._root_dir,
+            )
+            print(f"Deleting data {data_path}")
+            os.remove(data_path)
 
-		# Update the status of the dataset to deleted
-		with self._engine.connect() as conn:
-			update_stmt = (
-				update(dataset_table)
-				.where(dataset_table.c.dataset_id == dataset_id)
-				.values(
-					status=set_dataset_status(previous_dataset.status, deleted=True),
-					delete_date=datetime.now(),
-					delete_uid=self._uid,
-				)
-			)
-			conn.execute(update_stmt)
-			conn.commit()
-
-		# Delete the physical data in the root_dir
-		if previous_dataset.data_org != "dummy":
-			data_path = _form_dataset_path(
-				previous_dataset.owner_type,
-				previous_dataset.owner,
-				previous_dataset.relative_path,
-				schema=self._schema,
-				root_dir=self._root_dir,
-			)
-			print(f"Deleting data {data_path}")
-			os.remove(data_path)
-
-		print(f"Deleted {dataset_id} from data registry")
+        print(f"Deleted {dataset_id} from data registry")

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -395,7 +395,11 @@ class DatasetTable(BaseTable):
 
         # Search for dataset in the registry.
         dataset_table = self._get_table_metadata("dataset")
-        stmt = select(dataset_table)
+        stmt = select(
+            dataset_table.c.dataset_id,
+            dataset_table.c.is_overwritable,
+            dataset_table.c.is_overwritten,
+        )
 
         stmt = stmt.where(
             dataset_table.c.relative_path == relative_path,

--- a/src/dataregistry/schema/schema.yaml
+++ b/src/dataregistry/schema/schema.yaml
@@ -272,7 +272,7 @@ dataset:
   status:
     type: "Integer"
     nullable: False
-    description: "What is the status of the dataset? -1: Invalid (e.g., copy data failed during creation), 1: Valid, 2: Archived, 3: deleted"
+    description: "What is the status of the dataset? -1: Invalid (e.g., copy data failed during creation), 0: Valid dummy dataset 1: Valid dataset, 2: Archived, 3: deleted"
   archive_date:
     type: "DateTime"
     description: "Dataset archive date"

--- a/tests/end_to_end_tests/test_end_to_end.py
+++ b/tests/end_to_end_tests/test_end_to_end.py
@@ -12,940 +12,918 @@ from dataregistry.registrar.registrar_util import _form_dataset_path
 
 @pytest.fixture
 def dummy_file(tmp_path):
-    """
-    Create some dummy (temporary) files and directories
+	"""
+	Create some dummy (temporary) files and directories
 
-    Parameters
-    ----------
-    tmp_path : pathlib.Path object
+	Parameters
+	----------
+	tmp_path : pathlib.Path object
 
-    Returns
-    -------
-    tmp_src_dir : pathlib.Path object
-        Temporary files we are going to be copying into the registry will be
-        created in here
-    tmp_root_dir : pathlib.Path object
-        Temporary root_dir for the registry we can copy files to
-    """
+	Returns
+	-------
+	tmp_src_dir : pathlib.Path object
+		Temporary files we are going to be copying into the registry will be
+		created in here
+	tmp_root_dir : pathlib.Path object
+		Temporary root_dir for the registry we can copy files to
+	"""
 
-    # Temp dir for files that we copy files from (old_location)
-    tmp_src_dir = tmp_path / "source"
-    tmp_src_dir.mkdir()
+	# Temp dir for files that we copy files from (old_location)
+	tmp_src_dir = tmp_path / "source"
+	tmp_src_dir.mkdir()
 
-    for i in range(2):
-        f = tmp_src_dir / f"file{i+1}.txt"
-        f.write_text("i am a dummy file")
+	for i in range(2):
+		f = tmp_src_dir / f"file{i+1}.txt"
+		f.write_text("i am a dummy file")
 
-    p = tmp_src_dir / "directory1"
-    p.mkdir()
-    f = p / "file2.txt"
-    f.write_text("i am another dummy file")
+	p = tmp_src_dir / "directory1"
+	p.mkdir()
+	f = p / "file2.txt"
+	f.write_text("i am another dummy file")
 
-    # Temp root_dir of the registry
-    tmp_root_dir = tmp_path / "root_dir"
-    for THIS_SCHEMA in [SCHEMA_VERSION + "/", ""]:
-        p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}/dummy_dir"
-        p.mkdir(parents=True)
+	# Temp root_dir of the registry
+	tmp_root_dir = tmp_path / "root_dir"
+	for THIS_SCHEMA in [SCHEMA_VERSION + "/", ""]:
+		p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}/dummy_dir"
+		p.mkdir(parents=True)
 
-        f = p / "file1.txt"
-        f.write_text("i am another dummy file (but on location in a dir)")
+		f = p / "file1.txt"
+		f.write_text("i am another dummy file (but on location in a dir)")
 
-        p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}"
-        f = p / "file1.txt"
-        f.write_text("i am another dummy file (but on location)")
+		p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}"
+		f = p / "file1.txt"
+		f.write_text("i am another dummy file (but on location)")
 
-    # Make a dummy configuration yaml file
-    data = {
-        "run_by": "somebody",
-        "software_version": {"major": 1, "minor": 1, "patch": 0},
-        "an_important_list": [1, 2, 3],
-    }
+	# Make a dummy configuration yaml file
+	data = {
+		"run_by": "somebody",
+		"software_version": {"major": 1, "minor": 1, "patch": 0},
+		"an_important_list": [1, 2, 3],
+	}
 
-    # Write the data to the YAML file
-    with open(tmp_src_dir / "dummy_configuration_file.yaml", "w") as file:
-        yaml.dump(data, file, default_flow_style=False)
+	# Write the data to the YAML file
+	with open(tmp_src_dir / "dummy_configuration_file.yaml", "w") as file:
+		yaml.dump(data, file, default_flow_style=False)
 
-    return tmp_src_dir, tmp_root_dir
+	return tmp_src_dir, tmp_root_dir
 
 
 def _insert_alias_entry(datareg, name, dataset_id):
-    """
-    Wrapper to create dataset alias entry
+	"""
+	Wrapper to create dataset alias entry
 
-    Parameters
-    ----------
-    name : str
-        Name of alias
-    dataset_id : int
-        Dataset we are assigning alias name to
+	Parameters
+	----------
+	name : str
+		Name of alias
+	dataset_id : int
+		Dataset we are assigning alias name to
 
-    Returns
-    -------
-    new_id : int
-        The alias ID for this new entry
-    """
+	Returns
+	-------
+	new_id : int
+		The alias ID for this new entry
+	"""
 
-    new_id = datareg.Registrar.dataset_alias.create(name, dataset_id)
+	new_id = datareg.Registrar.dataset_alias.create(name, dataset_id)
 
-    assert new_id is not None, "Trying to create a dataset alias that already exists"
-    print(f"Created dataset alias entry with id {new_id}")
+	assert new_id is not None, "Trying to create a dataset alias that already exists"
+	print(f"Created dataset alias entry with id {new_id}")
 
-    return new_id
+	return new_id
 
 
 def _insert_execution_entry(
-    datareg, name, description, input_datasets=[], configuration=None
+	datareg, name, description, input_datasets=[], configuration=None
 ):
-    """
-    Wrapper to create execution entry
+	"""
+	Wrapper to create execution entry
 
-    Parameters
-    ----------
-    name : str
-        Name of execution
-    description : str
-        Description of execution
-    intput_datasets : list
-        List of dataset ids
-    configuration : str
-        Path to configuration file for execution
+	Parameters
+	----------
+	name : str
+		Name of execution
+	description : str
+		Description of execution
+	intput_datasets : list
+		List of dataset ids
+	configuration : str
+		Path to configuration file for execution
 
-    Returns
-    -------
-    new_id : int
-        The execution ID for this new entry
-    """
+	Returns
+	-------
+	new_id : int
+		The execution ID for this new entry
+	"""
 
-    new_id = datareg.Registrar.execution.create(
-        name,
-        description=description,
-        input_datasets=input_datasets,
-        configuration=configuration,
-    )
+	new_id = datareg.Registrar.execution.create(
+		name,
+		description=description,
+		input_datasets=input_datasets,
+		configuration=configuration,
+	)
 
-    assert new_id is not None, "Trying to create a execution that already exists"
-    print(f"Created execution entry with id {new_id}")
+	assert new_id is not None, "Trying to create a execution that already exists"
+	print(f"Created execution entry with id {new_id}")
 
-    return new_id
+	return new_id
 
 
 def _insert_dataset_entry(
-    datareg,
-    relpath,
-    version,
-    owner_type,
-    owner,
-    description,
-    name=None,
-    execution_id=None,
-    version_suffix=None,
-    is_dummy=True,
-    old_location=None,
-    is_overwritable=False,
-    which_datareg=None,
-    execution_name=None,
-    execution_description=None,
-    execution_start=None,
-    execution_locale=None,
-    execution_configuration=None,
-    input_datasets=[],
+	datareg,
+	relpath,
+	version,
+	owner_type,
+	owner,
+	description,
+	name=None,
+	execution_id=None,
+	version_suffix=None,
+	is_dummy=True,
+	old_location=None,
+	is_overwritable=False,
+	which_datareg=None,
+	execution_name=None,
+	execution_description=None,
+	execution_start=None,
+	execution_locale=None,
+	execution_configuration=None,
+	input_datasets=[],
 ):
-    """
-    Wrapper to create dataset entry
+	"""
+	Wrapper to create dataset entry
 
-    Parameters
-    ----------
-    relpath : str
-        Relative path within the data registry to store the data
-        Relative to <ROOT>/<owner_type>/<owner>/...
-    version : str
-        Semantic version string (i.e., M.N.P) or
-        "major", "minor", "patch" to automatically bump the version previous
-    owner_type : str
-        Either "production", "group", "user"
-    owner : str
-        Dataset owner
-    description : str
-        Description of dataset
-    name : str
-        A manually selected name for the dataset
-    execution_id : int
-        Execution entry related to this dataset
-    version_suffix : str
-        Append a suffix to the version string
-    is_dummy : bool
-        True for dummy dataset (copies no data)
-    old_location : str
-        Path to data to be copied to data registry
-    which_datareg : DataRegistry object
-        In case we want to register using a custom DataRegistry object
-    execution_name : str, optional
-            Typically pipeline name or program name
-    execution_description : str, optional
-        Human readible description of execution
-    execution_start : datetime, optional
-        Date the execution started
-    execution_locale : str, optional
-        Where was the execution performed?
-    execution_configuration : str, optional
-        Path to text file used to configure the execution
-    input_datasets : list, optional
-        List of dataset ids that were the input to this execution
+	Parameters
+	----------
+	relpath : str
+		Relative path within the data registry to store the data
+		Relative to <ROOT>/<owner_type>/<owner>/...
+	version : str
+		Semantic version string (i.e., M.N.P) or
+		"major", "minor", "patch" to automatically bump the version previous
+	owner_type : str
+		Either "production", "group", "user"
+	owner : str
+		Dataset owner
+	description : str
+		Description of dataset
+	name : str
+		A manually selected name for the dataset
+	execution_id : int
+		Execution entry related to this dataset
+	version_suffix : str
+		Append a suffix to the version string
+	is_dummy : bool
+		True for dummy dataset (copies no data)
+	old_location : str
+		Path to data to be copied to data registry
+	which_datareg : DataRegistry object
+		In case we want to register using a custom DataRegistry object
+	execution_name : str, optional
+			Typically pipeline name or program name
+	execution_description : str, optional
+		Human readible description of execution
+	execution_start : datetime, optional
+		Date the execution started
+	execution_locale : str, optional
+		Where was the execution performed?
+	execution_configuration : str, optional
+		Path to text file used to configure the execution
+	input_datasets : list, optional
+		List of dataset ids that were the input to this execution
 
-    Returns
-    -------
-    dataset_id : int
-        The dataset it created for this entry
-    """
+	Returns
+	-------
+	dataset_id : int
+		The dataset it created for this entry
+	"""
 
-    # Some defaults over all test datasets
-    locale = "NERSC"
-    creation_data = None
-    make_sym_link = False
+	# Some defaults over all test datasets
+	locale = "NERSC"
+	creation_data = None
+	make_sym_link = False
 
-    # Add new entry.
-    dataset_id, execution_id = datareg.Registrar.dataset.create(
-        relpath,
-        version,
-        version_suffix=version_suffix,
-        name=name,
-        creation_date=creation_data,
-        description=description,
-        old_location=old_location,
-        copy=(not make_sym_link),
-        is_dummy=is_dummy,
-        execution_id=execution_id,
-        verbose=True,
-        owner=owner,
-        owner_type=owner_type,
-        is_overwritable=is_overwritable,
-        execution_name=execution_name,
-        execution_description=execution_description,
-        execution_start=execution_start,
-        execution_locale=execution_locale,
-        execution_configuration=execution_configuration,
-        input_datasets=input_datasets,
-    )
+	# Add new entry.
+	dataset_id, execution_id = datareg.Registrar.dataset.create(
+		relpath,
+		version,
+		version_suffix=version_suffix,
+		name=name,
+		creation_date=creation_data,
+		description=description,
+		old_location=old_location,
+		copy=(not make_sym_link),
+		is_dummy=is_dummy,
+		execution_id=execution_id,
+		verbose=True,
+		owner=owner,
+		owner_type=owner_type,
+		is_overwritable=is_overwritable,
+		execution_name=execution_name,
+		execution_description=execution_description,
+		execution_start=execution_start,
+		execution_locale=execution_locale,
+		execution_configuration=execution_configuration,
+		input_datasets=input_datasets,
+	)
 
-    assert dataset_id is not None, "Trying to create a dataset that already exists"
-    assert execution_id is not None, "Trying to create a execution that already exists"
-    print(f"Created dataset entry with id {dataset_id}")
+	assert dataset_id is not None, "Trying to create a dataset that already exists"
+	assert execution_id is not None, "Trying to create a execution that already exists"
+	print(f"Created dataset entry with id {dataset_id}")
 
-    return dataset_id
+	return dataset_id
 
 
 def test_simple_query(dummy_file):
-    """Make a simple entry, and make sure the query returns the correct result"""
+	"""Make a simple entry, and make sure the query returns the correct result"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/my_first_dataset",
-        "0.0.1",
-        "user",
-        None,
-        "This is my first DESC dataset",
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/my_first_dataset",
+		"0.0.1",
+		"user",
+		None,
+		"This is my first DESC dataset",
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.name",
-            "dataset.version_string",
-            "dataset.owner",
-            "dataset.owner_type",
-            "dataset.description",
-            "dataset.version_major",
-            "dataset.version_minor",
-            "dataset.version_patch",
-            "dataset.relative_path",
-            "dataset.version_suffix",
-            "dataset.data_org",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.name",
+			"dataset.version_string",
+			"dataset.owner",
+			"dataset.owner_type",
+			"dataset.description",
+			"dataset.version_major",
+			"dataset.version_minor",
+			"dataset.version_patch",
+			"dataset.relative_path",
+			"dataset.version_suffix",
+			"dataset.data_org",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "my_first_dataset"
-        assert getattr(r, "dataset.version_string") == "0.0.1"
-        assert getattr(r, "dataset.version_major") == 0
-        assert getattr(r, "dataset.version_minor") == 0
-        assert getattr(r, "dataset.version_patch") == 1
-        assert getattr(r, "dataset.owner") == os.getenv("USER")
-        assert getattr(r, "dataset.owner_type") == "user"
-        assert getattr(r, "dataset.description") == "This is my first DESC dataset"
-        assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
-        assert getattr(r, "dataset.version_suffix") == None
-        assert getattr(r, "dataset.data_org") == "dummy"
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.name") == "my_first_dataset"
+		assert getattr(r, "dataset.version_string") == "0.0.1"
+		assert getattr(r, "dataset.version_major") == 0
+		assert getattr(r, "dataset.version_minor") == 0
+		assert getattr(r, "dataset.version_patch") == 1
+		assert getattr(r, "dataset.owner") == os.getenv("USER")
+		assert getattr(r, "dataset.owner_type") == "user"
+		assert getattr(r, "dataset.description") == "This is my first DESC dataset"
+		assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
+		assert getattr(r, "dataset.version_suffix") == None
+		assert getattr(r, "dataset.data_org") == "dummy"
+		assert i < 1
 
 
 def test_manual_name_and_vsuffix(dummy_file):
-    """Test setting the name and version suffix manually"""
+	"""Test setting the name and version suffix manually"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/my_second_dataset",
-        "0.0.1",
-        "user",
-        None,
-        "This is my first DESC dataset",
-        name="custom name",
-        version_suffix="custom_suffix",
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/my_second_dataset",
+		"0.0.1",
+		"user",
+		None,
+		"This is my first DESC dataset",
+		name="custom name",
+		version_suffix="custom_suffix",
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "custom name"
-        assert getattr(r, "dataset.version_suffix") == "custom_suffix"
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.name") == "custom name"
+		assert getattr(r, "dataset.version_suffix") == "custom_suffix"
+		assert i < 1
 
 
 @pytest.mark.parametrize(
-    "v_type,ans,name",
-    [
-        ("major", "1.0.0", "my_first_dataset"),
-        ("minor", "0.1.0", "my_first_dataset"),
-        ("patch", "0.0.2", "my_first_dataset"),
-        ("patch", "0.0.1", "my_second_dataset"),
-    ],
+	"v_type,ans,name",
+	[
+		("major", "1.0.0", "my_first_dataset"),
+		("minor", "0.1.0", "my_first_dataset"),
+		("patch", "0.0.2", "my_first_dataset"),
+		("patch", "0.0.1", "my_second_dataset"),
+	],
 )
 def test_dataset_bumping(dummy_file, v_type, ans, name):
-    """
-    Test bumping a dataset and make sure the new version is correct.
+	"""
+	Test bumping a dataset and make sure the new version is correct.
 
-    Tests bumping datasets with and without a version suffix.
-    """
+	Tests bumping datasets with and without a version suffix.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        f"DESC/datasets/bumped_dataset_{v_type}_{name}",
-        v_type,
-        "user",
-        None,
-        "This is my first bumped DESC dataset",
-        name=name,
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		f"DESC/datasets/bumped_dataset_{v_type}_{name}",
+		v_type,
+		"user",
+		None,
+		"This is my first bumped DESC dataset",
+		name=name,
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == name
-        assert getattr(r, "dataset.version_string") == ans
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.name") == name
+		assert getattr(r, "dataset.version_string") == ans
+		assert i < 1
 
 
 @pytest.mark.parametrize("owner_type", ["user", "group", "project"])
 def test_owner_types(dummy_file, owner_type):
-    """Test the different owner types"""
+	"""Test the different owner types"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        f"DESC/datasets/owner_type_{owner_type}",
-        "0.0.1",
-        owner_type,
-        None,
-        f"This is a {owner_type} dataset",
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		f"DESC/datasets/owner_type_{owner_type}",
+		"0.0.1",
+		owner_type,
+		None,
+		f"This is a {owner_type} dataset",
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        ["dataset.owner_type"], [f], return_format="cursorresult"
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		["dataset.owner_type"], [f], return_format="cursorresult"
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.owner_type") == owner_type
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.owner_type") == owner_type
+		assert i < 1
 
 
 @pytest.mark.parametrize("data_org", ["file", "directory"])
 def test_copy_data(dummy_file, data_org):
-    """Test copying real data into the registry (from an `old_location`)"""
+	"""Test copying real data into the registry (from an `old_location`)"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # File/directory we are copying in
-    if data_org == "file":
-        data_path = str(tmp_src_dir / "file1.txt")
-    else:
-        data_path = str(tmp_src_dir / "directory1")
+	# File/directory we are copying in
+	if data_org == "file":
+		data_path = str(tmp_src_dir / "file1.txt")
+	else:
+		data_path = str(tmp_src_dir / "directory1")
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        f"DESC/datasets/copy_real_{data_org}",
-        "0.0.1",
-        "user",
-        None,
-        "Test copying a real file",
-        old_location=data_path,
-        is_dummy=False,
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		f"DESC/datasets/copy_real_{data_org}",
+		"0.0.1",
+		"user",
+		None,
+		"Test copying a real file",
+		old_location=data_path,
+		is_dummy=False,
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        ["dataset.data_org", "dataset.nfiles", "dataset.total_disk_space"],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		["dataset.data_org", "dataset.nfiles", "dataset.total_disk_space"],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.data_org") == data_org
-        assert getattr(r, "dataset.nfiles") == 1
-        assert getattr(r, "dataset.total_disk_space") > 0
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.data_org") == data_org
+		assert getattr(r, "dataset.nfiles") == 1
+		assert getattr(r, "dataset.total_disk_space") > 0
+		assert i < 1
 
 
 @pytest.mark.parametrize(
-    "data_org,data_path,v_str,overwritable",
-    [
-        ("file", "file1.txt", "0.0.1", True),
-        ("file", "file1.txt", "0.0.2", False),
-        ("directory", "dummy_dir", "0.0.1", True),
-        ("directory", "dummy_dir", "0.0.2", False),
-    ],
+	"data_org,data_path,v_str,overwritable",
+	[
+		("file", "file1.txt", "0.0.1", True),
+		("file", "file1.txt", "0.0.2", False),
+		("directory", "dummy_dir", "0.0.1", True),
+		("directory", "dummy_dir", "0.0.2", False),
+	],
 )
 def test_on_location_data(dummy_file, data_org, data_path, v_str, overwritable):
-    """
-    Test ingesting real data into the registry (already on location). Also
-    tests overwriting datasets.
+	"""
+	Test ingesting real data into the registry (already on location). Also
+	tests overwriting datasets.
 
-    Does twice for each file, the first is a normal entry with
-    `is_overwritable=True`. The second tests overwriting the previous data with
-    a new version.
-    """
+	Does twice for each file, the first is a normal entry with
+	`is_overwritable=True`. The second tests overwriting the previous data with
+	a new version.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    d_id = _insert_dataset_entry(
-        datareg,
-        data_path,
-        v_str,
-        "user",
-        None,
-        "Test ingesting a real file on location",
-        old_location=None,
-        is_dummy=False,
-        is_overwritable=overwritable,
-    )
+	d_id = _insert_dataset_entry(
+		datareg,
+		data_path,
+		v_str,
+		"user",
+		None,
+		"Test ingesting a real file on location",
+		old_location=None,
+		is_dummy=False,
+		is_overwritable=overwritable,
+	)
 
-    f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.data_org",
-            "dataset.nfiles",
-            "dataset.total_disk_space",
-            "dataset.is_overwritable",
-            "dataset.is_overwritten",
-            "dataset.version_string",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.data_org",
+			"dataset.nfiles",
+			"dataset.total_disk_space",
+			"dataset.is_overwritable",
+			"dataset.is_overwritten",
+			"dataset.version_string",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    num_results = len(results.all())
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.data_org") == data_org
-        assert getattr(r, "dataset.nfiles") == 1
-        assert getattr(r, "dataset.total_disk_space") > 0
-        if getattr(r, "version_string") == "0.0.1":
-            if num_results == 1:
-                assert getattr(r, "dataset.is_overwritable") == True
-                assert getattr(r, "dataset.is_overwritten") == False
-            else:
-                assert getattr(r, "dataset.is_overwritable") == True
-                assert getattr(r, "dataset.is_overwritten") == True
-        else:
-            if num_results == 1:
-                assert getattr(r, "dataset.is_overwritable") == False
-                assert getattr(r, "dataset.is_overwritten") == True
-            else:
-                assert getattr(r, "dataset.is_overwritable") == False
-                assert getattr(r, "dataset.is_overwritten") == False
-        assert i < 2
+	num_results = len(results.all())
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.data_org") == data_org
+		assert getattr(r, "dataset.nfiles") == 1
+		assert getattr(r, "dataset.total_disk_space") > 0
+		if getattr(r, "version_string") == "0.0.1":
+			if num_results == 1:
+				assert getattr(r, "dataset.is_overwritable") == True
+				assert getattr(r, "dataset.is_overwritten") == False
+			else:
+				assert getattr(r, "dataset.is_overwritable") == True
+				assert getattr(r, "dataset.is_overwritten") == True
+		else:
+			if num_results == 1:
+				assert getattr(r, "dataset.is_overwritable") == False
+				assert getattr(r, "dataset.is_overwritten") == True
+			else:
+				assert getattr(r, "dataset.is_overwritable") == False
+				assert getattr(r, "dataset.is_overwritten") == False
+		assert i < 2
 
 
 def test_dataset_alias(dummy_file):
-    """Register a dataset and make a dataset alias entry for it"""
+	"""Register a dataset and make a dataset alias entry for it"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add dataset
-    d_id = _insert_dataset_entry(
-        datareg,
-        "alias_test_entry",
-        "0.0.1",
-        "user",
-        None,
-        "Test dataset alias",
-    )
+	# Add dataset
+	d_id = _insert_dataset_entry(
+		datareg,
+		"alias_test_entry",
+		"0.0.1",
+		"user",
+		None,
+		"Test dataset alias",
+	)
 
-    # Add alias
-    _insert_alias_entry(datareg, "nice_dataset_name", d_id)
+	# Add alias
+	_insert_alias_entry(datareg, "nice_dataset_name", d_id)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset_alias.alias", "==", "nice_dataset_name")
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.dataset_id",
-            "dataset_alias.dataset_id",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset_alias.alias", "==", "nice_dataset_name")
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.dataset_id",
+			"dataset_alias.dataset_id",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.dataset_id") == d_id
-        assert getattr(r, "dataset_alias.dataset_id") == d_id
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.dataset_id") == d_id
+		assert getattr(r, "dataset_alias.dataset_id") == d_id
+		assert i < 1
 
 
 def test_pipeline_entry(dummy_file):
-    """
-    Test making multiple executions and datasets to form a pipeline.
+	"""
+	Test making multiple executions and datasets to form a pipeline.
 
-    Also queries to make sure dependencies are made.
-    """
+	Also queries to make sure dependencies are made.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entries
-    ex_id_1 = _insert_execution_entry(
-        datareg, "pipeline_stage_1", "The first stage of my pipeline"
-    )
+	# Add entries
+	ex_id_1 = _insert_execution_entry(
+		datareg, "pipeline_stage_1", "The first stage of my pipeline"
+	)
 
-    d_id_1 = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/my_first_pipeline_stage1",
-        "0.0.1",
-        "user",
-        None,
-        "This is data for stage 1 of my first pipeline",
-        execution_id=ex_id_1,
-    )
+	d_id_1 = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/my_first_pipeline_stage1",
+		"0.0.1",
+		"user",
+		None,
+		"This is data for stage 1 of my first pipeline",
+		execution_id=ex_id_1,
+	)
 
-    ex_id_2 = _insert_execution_entry(
-        datareg,
-        "pipeline_stage_2",
-        "The second stage of my pipeline",
-        input_datasets=[d_id_1],
-    )
+	ex_id_2 = _insert_execution_entry(
+		datareg,
+		"pipeline_stage_2",
+		"The second stage of my pipeline",
+		input_datasets=[d_id_1],
+	)
 
-    d_id_2 = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/my_first_pipeline_stage2a",
-        "0.0.1",
-        "user",
-        None,
-        "This is data for stage 2 of my first pipeline",
-        execution_id=ex_id_2,
-    )
+	d_id_2 = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/my_first_pipeline_stage2a",
+		"0.0.1",
+		"user",
+		None,
+		"This is data for stage 2 of my first pipeline",
+		execution_id=ex_id_2,
+	)
 
-    d_id_3 = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/my_first_pipeline_stage2b",
-        "0.0.1",
-        "user",
-        None,
-        "This is data for stage 2 of my first pipeline",
-        execution_id=ex_id_2,
-    )
+	d_id_3 = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/my_first_pipeline_stage2b",
+		"0.0.1",
+		"user",
+		None,
+		"This is data for stage 2 of my first pipeline",
+		execution_id=ex_id_2,
+	)
 
-    # Stage 3 of my pipeline
-    ex_id_3 = _insert_execution_entry(
-        datareg,
-        "pipeline_stage_3",
-        "The third stage of my pipeline",
-        input_datasets=[d_id_2, d_id_3],
-    )
+	# Stage 3 of my pipeline
+	ex_id_3 = _insert_execution_entry(
+		datareg,
+		"pipeline_stage_3",
+		"The third stage of my pipeline",
+		input_datasets=[d_id_2, d_id_3],
+	)
 
-    # Query on execution
-    f = datareg.Query.gen_filter("dataset.execution_id", "==", ex_id_2)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.name",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query on execution
+	f = datareg.Query.gen_filter("dataset.execution_id", "==", ex_id_2)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.name",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert "my_first_pipeline_stage2" in getattr(r, "dataset.name")
-        assert i < 2
+	for i, r in enumerate(results):
+		assert "my_first_pipeline_stage2" in getattr(r, "dataset.name")
+		assert i < 2
 
-    # Query on dependency
-    f = datareg.Query.gen_filter("dependency.execution_id", "==", ex_id_2)
-    results = datareg.Query.find_datasets(
-        [
-            "dependency.execution_id",
-            "dataset.dataset_id",
-            "dataset.execution_id",
-            "dataset.name",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query on dependency
+	f = datareg.Query.gen_filter("dependency.execution_id", "==", ex_id_2)
+	results = datareg.Query.find_datasets(
+		[
+			"dependency.execution_id",
+			"dataset.dataset_id",
+			"dataset.execution_id",
+			"dataset.name",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.dataset_id") == d_id_1
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.dataset_id") == d_id_1
+		assert i < 1
 
 
 def test_global_owner_set(dummy_file):
-    """
-    Test setting the owner and owner_type globally during the database
-    initialization.
-    """
+	"""
+	Test setting the owner and owner_type globally during the database
+	initialization.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(
-        root_dir=str(tmp_root_dir),
-        schema=SCHEMA_VERSION,
-        owner="DESC group",
-        owner_type="group",
-    )
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(
+		root_dir=str(tmp_root_dir),
+		schema=SCHEMA_VERSION,
+		owner="DESC group",
+		owner_type="group",
+	)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/global_user_dataset",
-        "0.0.1",
-        None,
-        None,
-        "Should be allocated user and user_type from global config",
-    )
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/global_user_dataset",
+		"0.0.1",
+		None,
+		None,
+		"Should be allocated user and user_type from global config",
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.owner",
-            "dataset.owner_type",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.owner",
+			"dataset.owner_type",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.owner") == "DESC group"
-        assert getattr(r, "dataset.owner_type") == "group"
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.owner") == "DESC group"
+		assert getattr(r, "dataset.owner_type") == "group"
+		assert i < 1
 
 
 @pytest.mark.skip(reason="Can't do production related things with sqlite")
 def test_prooduction_schema(dummy_file):
-    """
-    Test making multiple executions and datasets to form a pipeline.
+	"""
+	Test making multiple executions and datasets to form a pipeline.
 
-    Also queries to make sure dependencies are made.
-    """
+	Also queries to make sure dependencies are made.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema="production")
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema="production")
 
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/production_dataset_1",
-        "0.0.1",
-        "production",
-        None,
-        "This is production's first dataset",
-    )
+	d_id = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/production_dataset_1",
+		"0.0.1",
+		"production",
+		None,
+		"This is production's first dataset",
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.owner",
-            "dataset.owner_type",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.owner",
+			"dataset.owner_type",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dataset.owner") == "production"
-        assert getattr(r, "dataset.owner_type") == "production"
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dataset.owner") == "production"
+		assert getattr(r, "dataset.owner_type") == "production"
+		assert i < 1
 
 
 def test_execution_config_file(dummy_file):
-    """Test ingesting a configuration file with an execution entry"""
+	"""Test ingesting a configuration file with an execution entry"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Add entry
-    ex_id = _insert_execution_entry(
-        datareg,
-        "execution_with_configuration",
-        "An execution with an input configuration file",
-        configuration=str(tmp_src_dir / "dummy_configuration_file.yaml"),
-    )
+	# Add entry
+	ex_id = _insert_execution_entry(
+		datareg,
+		"execution_with_configuration",
+		"An execution with an input configuration file",
+		configuration=str(tmp_src_dir / "dummy_configuration_file.yaml"),
+	)
 
-    # Query
-    f = datareg.Query.gen_filter("execution.execution_id", "==", ex_id)
-    results = datareg.Query.find_datasets(
-        [
-            "execution.configuration",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query
+	f = datareg.Query.gen_filter("execution.execution_id", "==", ex_id)
+	results = datareg.Query.find_datasets(
+		[
+			"execution.configuration",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "execution.configuration") is not None
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "execution.configuration") is not None
+		assert i < 1
 
 
 def test_dataset_with_execution(dummy_file):
-    """
-    Test modifying the datasets default execution directly when registering the
-    dataset
-    """
+	"""
+	Test modifying the datasets default execution directly when registering the
+	dataset
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    d_id_1 = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/execution_test_input",
-        "0.0.1",
-        None,
-        None,
-        "This is production's first dataset",
-    )
+	d_id_1 = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/execution_test_input",
+		"0.0.1",
+		None,
+		None,
+		"This is production's first dataset",
+	)
 
-    d_id_2 = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/execution_test",
-        "0.0.1",
-        None,
-        None,
-        "This should have a more descriptive execution",
-        execution_name="Overwrite execution auto name",
-        execution_description="Overwrite execution auto description",
-        execution_locale="TestMachine",
-        input_datasets=[d_id_1],
-    )
+	d_id_2 = _insert_dataset_entry(
+		datareg,
+		"DESC/datasets/execution_test",
+		"0.0.1",
+		None,
+		None,
+		"This should have a more descriptive execution",
+		execution_name="Overwrite execution auto name",
+		execution_description="Overwrite execution auto description",
+		execution_locale="TestMachine",
+		input_datasets=[d_id_1],
+	)
 
-    # Query on execution
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id_2)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.name",
-            "execution.execution_id",
-            "execution.description",
-            "execution.locale",
-            "execution.name",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query on execution
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id_2)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.name",
+			"execution.execution_id",
+			"execution.description",
+			"execution.locale",
+			"execution.name",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "execution.name") == "Overwrite execution auto name"
-        assert (
-            getattr(r, "execution.description")
-            == "Overwrite execution auto description"
-        )
-        assert getattr(r, "execution.locale") == "TestMachine"
-        ex_id_1 = getattr(r, "execution.execution_id")
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "execution.name") == "Overwrite execution auto name"
+		assert (
+			getattr(r, "execution.description")
+			== "Overwrite execution auto description"
+		)
+		assert getattr(r, "execution.locale") == "TestMachine"
+		ex_id_1 = getattr(r, "execution.execution_id")
+		assert i < 1
 
-    # Query on dependency
-    f = datareg.Query.gen_filter("dependency.input_id", "==", d_id_1)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.dataset_id",
-            "dependency.execution_id",
-            "dependency.input_id",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Query on dependency
+	f = datareg.Query.gen_filter("dependency.input_id", "==", d_id_1)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.dataset_id",
+			"dependency.execution_id",
+			"dependency.input_id",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
-    for i, r in enumerate(results):
-        assert getattr(r, "dependency.execution_id") == ex_id_1
-        assert i < 1
+	for i, r in enumerate(results):
+		assert getattr(r, "dependency.execution_id") == ex_id_1
+		assert i < 1
 
 
 def test_get_dataset_absolute_path(dummy_file):
-    """
-    Test the generation of the full absolute path of a dataset using the
-    `Query.get_dataset_absolute_path` function
-    """
+	"""
+	Test the generation of the full absolute path of a dataset using the
+	`Query.get_dataset_absolute_path` function
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    dset_relpath = "DESC/datasets/get_dataset_absolute_path_test"
-    dset_ownertype = "group"
-    dset_owner = "group1"
+	dset_relpath = "DESC/datasets/get_dataset_absolute_path_test"
+	dset_ownertype = "group"
+	dset_owner = "group1"
 
-    # Make a basic entry
-    d_id_1 = _insert_dataset_entry(
-        datareg,
-        dset_relpath,
-        "0.0.1",
-        dset_ownertype,
-        dset_owner,
-        "Test the Query.get_dataset_absolute_path function",
-    )
+	# Make a basic entry
+	d_id_1 = _insert_dataset_entry(
+		datareg,
+		dset_relpath,
+		"0.0.1",
+		dset_ownertype,
+		dset_owner,
+		"Test the Query.get_dataset_absolute_path function",
+	)
 
-    v = datareg.Query.get_dataset_absolute_path(d_id_1)
+	v = datareg.Query.get_dataset_absolute_path(d_id_1)
 
-    if datareg.Query._dialect == "sqlite":
-        assert v == os.path.join(
-            str(tmp_root_dir), dset_ownertype, dset_owner, dset_relpath
-        )
-    else:
-        assert v == os.path.join(
-            str(tmp_root_dir), SCHEMA_VERSION, dset_ownertype, dset_owner, dset_relpath
-        )
+	if datareg.Query._dialect == "sqlite":
+		assert v == os.path.join(
+			str(tmp_root_dir), dset_ownertype, dset_owner, dset_relpath
+		)
+	else:
+		assert v == os.path.join(
+			str(tmp_root_dir), SCHEMA_VERSION, dset_ownertype, dset_owner, dset_relpath
+		)
 
+@pytest.mark.parametrize(
+	"is_dummy,dataset_name",
+	[
+		(True, "dummy_dataset_to_delete"),
+		(False, "real_dataset_to_delete"),
+	],
+)
+def test_delete_entry(dummy_file, is_dummy, dataset_name):
+	"""
+	Make a simple entry, then delete it, then check it was deleted.
 
-def test_delete_entry_dummy(dummy_file):
-    """Make a simple (dummy) entry, then delete it, then check it was deleted"""
+	Does this for a dummy dataset and a real one.
+	"""
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+	# Establish connection to database
+	tmp_src_dir, tmp_root_dir = dummy_file
+	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    # Make sure we raise an exception trying to delete a dataset that doesn't exist
-    with pytest.raises(ValueError, match="does not exist"):
-        datareg.Registrar.dataset.delete(10000)
+	# Make sure we raise an exception trying to delete a dataset that doesn't exist
+	with pytest.raises(ValueError, match="does not exist"):
+		datareg.Registrar.dataset.delete(10000)
 
-    # Add entry
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/dummy_dataset_to_delete",
-        "0.0.1",
-        "user",
-        None,
-        "A dataset to delete",
-    )
+	# Where is the real data?
+	if is_dummy:
+		data_path = None
+	else:
+		data_path = str(tmp_src_dir / "file2.txt")
+		assert os.path.isfile(data_path)
 
-    # Now delete that entry
-    datareg.Registrar.dataset.delete(d_id)
+	# Add entry
+	d_id = _insert_dataset_entry(
+		datareg,
+		f"DESC/datasets/{dataset_name}",
+		"0.0.1",
+		"user",
+		None,
+		"A dataset to delete",
+		is_dummy=is_dummy,
+		old_location=data_path,
+	)
 
-    # Check the entry was deleted
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.status",
-            "dataset.delete_date",
-            "dataset.delete_uid",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
+	# Now delete that entry
+	datareg.Registrar.dataset.delete(d_id)
 
-    for r in results:
-        assert getattr(r, "dataset.status") == 3
-        assert getattr(r, "dataset.delete_date") is not None
-        assert getattr(r, "dataset.delete_uid") is not None
+	# Check the entry was deleted
+	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+	results = datareg.Query.find_datasets(
+		[
+			"dataset.status",
+			"dataset.delete_date",
+			"dataset.delete_uid",
+			"dataset.owner_type",
+			"dataset.owner",
+			"dataset.relative_path",
+		],
+		[f],
+		return_format="cursorresult",
+	)
 
+	for r in results:
+		assert getattr(r, "dataset.status") == 3
+		assert getattr(r, "dataset.delete_date") is not None
+		assert getattr(r, "dataset.delete_uid") is not None
 
-def test_delete_entry_real(dummy_file):
-    """Make a simple (real data) entry, then delete it, then check it was deleted"""
+	if not is_dummy:
+		# Make sure the file in the root_dir has gone
+		data_path = _form_dataset_path(
+			getattr(r, "dataset.owner_type"),
+			getattr(r, "dataset.owner"),
+			getattr(r, "dataset.relative_path"),
+			schema=SCHEMA_VERSION,
+			root_dir=str(tmp_root_dir),
+		)
+		assert not os.path.isfile(data_path)
 
-    # Establish connection to database
-    tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
-
-    # Make sure we raise an exception trying to delete a dataset that doesn't exist
-    with pytest.raises(ValueError, match="does not exist"):
-        datareg.Registrar.dataset.delete(10000)
-
-    # Add entry
-    data_path = str(tmp_src_dir / "file2.txt")
-    assert os.path.isfile(data_path)
-    d_id = _insert_dataset_entry(
-        datareg,
-        "DESC/datasets/real_dataset_to_delete",
-        "0.0.1",
-        "user",
-        None,
-        "A dataset to delete",
-        old_location=data_path,
-        is_dummy=False,
-    )
-
-    # Now delete that entry
-    datareg.Registrar.dataset.delete(d_id)
-
-    # Check the entry was set to deleted in the registry
-    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-    results = datareg.Query.find_datasets(
-        [
-            "dataset.status",
-            "dataset.delete_date",
-            "dataset.delete_uid",
-            "dataset.owner",
-            "dataset.owner_type",
-            "dataset.relative_path",
-        ],
-        [f],
-        return_format="cursorresult",
-    )
-
-    for r in results:
-        assert getattr(r, "dataset.status") == 3
-        assert getattr(r, "dataset.delete_date") is not None
-        assert getattr(r, "dataset.delete_uid") is not None
-
-    # Make sure the file in the root_dir has gone
-    data_path = _form_dataset_path(
-        getattr(r, "dataset.owner_type"),
-        getattr(r, "dataset.owner"),
-        getattr(r, "dataset.relative_path"),
-        schema=SCHEMA_VERSION,
-        root_dir=str(tmp_root_dir),
-    )
-    assert not os.path.isfile(data_path)
+	# Make sure we can not delete an already deleted entry.
+	with pytest.raises(ValueError, match="not have a valid status"):
+		datareg.Registrar.dataset.delete(d_id)

--- a/tests/end_to_end_tests/test_end_to_end.py
+++ b/tests/end_to_end_tests/test_end_to_end.py
@@ -7,113 +7,114 @@ from dataregistry.db_basic import SCHEMA_VERSION
 import pytest
 
 from dataregistry.registrar.registrar_util import _form_dataset_path
+from dataregistry.registrar.dataset_util import set_dataset_status, get_dataset_status
 
 
 @pytest.fixture
 def dummy_file(tmp_path):
-	"""
-	Create some dummy (temporary) files and directories
+    """
+    Create some dummy (temporary) files and directories
 
-	Parameters
-	----------
-	tmp_path : pathlib.Path object
+    Parameters
+    ----------
+    tmp_path : pathlib.Path object
 
-	Returns
-	-------
-	tmp_src_dir : pathlib.Path object
-		Temporary files we are going to be copying into the registry will be
-		created in here
-	tmp_root_dir : pathlib.Path object
-		Temporary root_dir for the registry we can copy files to
-	"""
+    Returns
+    -------
+    tmp_src_dir : pathlib.Path object
+        Temporary files we are going to be copying into the registry will be
+        created in here
+    tmp_root_dir : pathlib.Path object
+        Temporary root_dir for the registry we can copy files to
+    """
 
-	# Temp dir for files that we copy files from (old_location)
-	tmp_src_dir = tmp_path / "source"
-	tmp_src_dir.mkdir()
+    # Temp dir for files that we copy files from (old_location)
+    tmp_src_dir = tmp_path / "source"
+    tmp_src_dir.mkdir()
 
-	for i in range(2):
-		f = tmp_src_dir / f"file{i+1}.txt"
-		f.write_text("i am a dummy file")
+    for i in range(2):
+        f = tmp_src_dir / f"file{i+1}.txt"
+        f.write_text("i am a dummy file")
 
-	p = tmp_src_dir / "directory1"
-	p.mkdir()
-	f = p / "file2.txt"
-	f.write_text("i am another dummy file")
+    p = tmp_src_dir / "directory1"
+    p.mkdir()
+    f = p / "file2.txt"
+    f.write_text("i am another dummy file")
 
-	# Temp root_dir of the registry
-	tmp_root_dir = tmp_path / "root_dir"
-	for THIS_SCHEMA in [SCHEMA_VERSION + "/", ""]:
-		p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}/dummy_dir"
-		p.mkdir(parents=True)
+    # Temp root_dir of the registry
+    tmp_root_dir = tmp_path / "root_dir"
+    for THIS_SCHEMA in [SCHEMA_VERSION + "/", ""]:
+        p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}/dummy_dir"
+        p.mkdir(parents=True)
 
-		f = p / "file1.txt"
-		f.write_text("i am another dummy file (but on location in a dir)")
+        f = p / "file1.txt"
+        f.write_text("i am another dummy file (but on location in a dir)")
 
-		p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}"
-		f = p / "file1.txt"
-		f.write_text("i am another dummy file (but on location)")
+        p = tmp_root_dir / f"{THIS_SCHEMA}user/{os.getenv('USER')}"
+        f = p / "file1.txt"
+        f.write_text("i am another dummy file (but on location)")
 
-	# Make a dummy configuration yaml file
-	data = {
-		"run_by": "somebody",
-		"software_version": {"major": 1, "minor": 1, "patch": 0},
-		"an_important_list": [1, 2, 3],
-	}
+    # Make a dummy configuration yaml file
+    data = {
+        "run_by": "somebody",
+        "software_version": {"major": 1, "minor": 1, "patch": 0},
+        "an_important_list": [1, 2, 3],
+    }
 
-	# Write the data to the YAML file
-	with open(tmp_src_dir / "dummy_configuration_file.yaml", "w") as file:
-		yaml.dump(data, file, default_flow_style=False)
+    # Write the data to the YAML file
+    with open(tmp_src_dir / "dummy_configuration_file.yaml", "w") as file:
+        yaml.dump(data, file, default_flow_style=False)
 
-	return tmp_src_dir, tmp_root_dir
+    return tmp_src_dir, tmp_root_dir
 
 
 def _insert_alias_entry(datareg, name, dataset_id):
-	"""
-	Wrapper to create dataset alias entry
+    """
+    Wrapper to create dataset alias entry
 
-	Parameters
-	----------
-	name : str
-		Name of alias
-	dataset_id : int
-		Dataset we are assigning alias name to
+    Parameters
+    ----------
+    name : str
+        Name of alias
+    dataset_id : int
+        Dataset we are assigning alias name to
 
-	Returns
-	-------
-	new_id : int
-		The alias ID for this new entry
-	"""
+    Returns
+    -------
+    new_id : int
+        The alias ID for this new entry
+    """
 
     new_id = datareg.Registrar.dataset_alias.register(name, dataset_id)
 
-	assert new_id is not None, "Trying to create a dataset alias that already exists"
-	print(f"Created dataset alias entry with id {new_id}")
+    assert new_id is not None, "Trying to create a dataset alias that already exists"
+    print(f"Created dataset alias entry with id {new_id}")
 
-	return new_id
+    return new_id
 
 
 def _insert_execution_entry(
-	datareg, name, description, input_datasets=[], configuration=None
+    datareg, name, description, input_datasets=[], configuration=None
 ):
-	"""
-	Wrapper to create execution entry
+    """
+    Wrapper to create execution entry
 
-	Parameters
-	----------
-	name : str
-		Name of execution
-	description : str
-		Description of execution
-	intput_datasets : list
-		List of dataset ids
-	configuration : str
-		Path to configuration file for execution
+    Parameters
+    ----------
+    name : str
+        Name of execution
+    description : str
+        Description of execution
+    intput_datasets : list
+        List of dataset ids
+    configuration : str
+        Path to configuration file for execution
 
-	Returns
-	-------
-	new_id : int
-		The execution ID for this new entry
-	"""
+    Returns
+    -------
+    new_id : int
+        The execution ID for this new entry
+    """
 
 
     new_id = datareg.Registrar.execution.register(
@@ -123,85 +124,85 @@ def _insert_execution_entry(
         configuration=configuration,
     )
 
-	assert new_id is not None, "Trying to create a execution that already exists"
-	print(f"Created execution entry with id {new_id}")
+    assert new_id is not None, "Trying to create a execution that already exists"
+    print(f"Created execution entry with id {new_id}")
 
-	return new_id
+    return new_id
 
 
 def _insert_dataset_entry(
-	datareg,
-	relpath,
-	version,
-	owner_type,
-	owner,
-	description,
-	name=None,
-	execution_id=None,
-	version_suffix=None,
-	is_dummy=True,
-	old_location=None,
-	is_overwritable=False,
-	which_datareg=None,
-	execution_name=None,
-	execution_description=None,
-	execution_start=None,
-	execution_locale=None,
-	execution_configuration=None,
-	input_datasets=[],
+    datareg,
+    relpath,
+    version,
+    owner_type,
+    owner,
+    description,
+    name=None,
+    execution_id=None,
+    version_suffix=None,
+    is_dummy=True,
+    old_location=None,
+    is_overwritable=False,
+    which_datareg=None,
+    execution_name=None,
+    execution_description=None,
+    execution_start=None,
+    execution_locale=None,
+    execution_configuration=None,
+    input_datasets=[],
 ):
-	"""
-	Wrapper to create dataset entry
+    """
+    Wrapper to create dataset entry
 
-	Parameters
-	----------
-	relpath : str
-		Relative path within the data registry to store the data
-		Relative to <ROOT>/<owner_type>/<owner>/...
-	version : str
-		Semantic version string (i.e., M.N.P) or
-		"major", "minor", "patch" to automatically bump the version previous
-	owner_type : str
-		Either "production", "group", "user"
-	owner : str
-		Dataset owner
-	description : str
-		Description of dataset
-	name : str
-		A manually selected name for the dataset
-	execution_id : int
-		Execution entry related to this dataset
-	version_suffix : str
-		Append a suffix to the version string
-	is_dummy : bool
-		True for dummy dataset (copies no data)
-	old_location : str
-		Path to data to be copied to data registry
-	which_datareg : DataRegistry object
-		In case we want to register using a custom DataRegistry object
-	execution_name : str, optional
-			Typically pipeline name or program name
-	execution_description : str, optional
-		Human readible description of execution
-	execution_start : datetime, optional
-		Date the execution started
-	execution_locale : str, optional
-		Where was the execution performed?
-	execution_configuration : str, optional
-		Path to text file used to configure the execution
-	input_datasets : list, optional
-		List of dataset ids that were the input to this execution
+    Parameters
+    ----------
+    relpath : str
+        Relative path within the data registry to store the data
+        Relative to <ROOT>/<owner_type>/<owner>/...
+    version : str
+        Semantic version string (i.e., M.N.P) or
+        "major", "minor", "patch" to automatically bump the version previous
+    owner_type : str
+        Either "production", "group", "user"
+    owner : str
+        Dataset owner
+    description : str
+        Description of dataset
+    name : str
+        A manually selected name for the dataset
+    execution_id : int
+        Execution entry related to this dataset
+    version_suffix : str
+        Append a suffix to the version string
+    is_dummy : bool
+        True for dummy dataset (copies no data)
+    old_location : str
+        Path to data to be copied to data registry
+    which_datareg : DataRegistry object
+        In case we want to register using a custom DataRegistry object
+    execution_name : str, optional
+            Typically pipeline name or program name
+    execution_description : str, optional
+        Human readible description of execution
+    execution_start : datetime, optional
+        Date the execution started
+    execution_locale : str, optional
+        Where was the execution performed?
+    execution_configuration : str, optional
+        Path to text file used to configure the execution
+    input_datasets : list, optional
+        List of dataset ids that were the input to this execution
 
-	Returns
-	-------
-	dataset_id : int
-		The dataset it created for this entry
-	"""
+    Returns
+    -------
+    dataset_id : int
+        The dataset it created for this entry
+    """
 
-	# Some defaults over all test datasets
-	locale = "NERSC"
-	creation_data = None
-	make_sym_link = False
+    # Some defaults over all test datasets
+    locale = "NERSC"
+    creation_data = None
+    make_sym_link = False
 
     # Add new entry.
     dataset_id, execution_id = datareg.Registrar.dataset.register(
@@ -227,703 +228,703 @@ def _insert_dataset_entry(
         input_datasets=input_datasets,
     )
 
-	assert dataset_id is not None, "Trying to create a dataset that already exists"
-	assert execution_id is not None, "Trying to create a execution that already exists"
-	print(f"Created dataset entry with id {dataset_id}")
+    assert dataset_id is not None, "Trying to create a dataset that already exists"
+    assert execution_id is not None, "Trying to create a execution that already exists"
+    print(f"Created dataset entry with id {dataset_id}")
 
-	return dataset_id
+    return dataset_id
 
 
 def test_simple_query(dummy_file):
-	"""Make a simple entry, and make sure the query returns the correct result"""
+    """Make a simple entry, and make sure the query returns the correct result"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/my_first_dataset",
-		"0.0.1",
-		"user",
-		None,
-		"This is my first DESC dataset",
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/my_first_dataset",
+        "0.0.1",
+        "user",
+        None,
+        "This is my first DESC dataset",
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.name",
-			"dataset.version_string",
-			"dataset.owner",
-			"dataset.owner_type",
-			"dataset.description",
-			"dataset.version_major",
-			"dataset.version_minor",
-			"dataset.version_patch",
-			"dataset.relative_path",
-			"dataset.version_suffix",
-			"dataset.data_org",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.name",
+            "dataset.version_string",
+            "dataset.owner",
+            "dataset.owner_type",
+            "dataset.description",
+            "dataset.version_major",
+            "dataset.version_minor",
+            "dataset.version_patch",
+            "dataset.relative_path",
+            "dataset.version_suffix",
+            "dataset.data_org",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.name") == "my_first_dataset"
-		assert getattr(r, "dataset.version_string") == "0.0.1"
-		assert getattr(r, "dataset.version_major") == 0
-		assert getattr(r, "dataset.version_minor") == 0
-		assert getattr(r, "dataset.version_patch") == 1
-		assert getattr(r, "dataset.owner") == os.getenv("USER")
-		assert getattr(r, "dataset.owner_type") == "user"
-		assert getattr(r, "dataset.description") == "This is my first DESC dataset"
-		assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
-		assert getattr(r, "dataset.version_suffix") == None
-		assert getattr(r, "dataset.data_org") == "dummy"
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.name") == "my_first_dataset"
+        assert getattr(r, "dataset.version_string") == "0.0.1"
+        assert getattr(r, "dataset.version_major") == 0
+        assert getattr(r, "dataset.version_minor") == 0
+        assert getattr(r, "dataset.version_patch") == 1
+        assert getattr(r, "dataset.owner") == os.getenv("USER")
+        assert getattr(r, "dataset.owner_type") == "user"
+        assert getattr(r, "dataset.description") == "This is my first DESC dataset"
+        assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
+        assert getattr(r, "dataset.version_suffix") == None
+        assert getattr(r, "dataset.data_org") == "dummy"
+        assert i < 1
 
 
 def test_manual_name_and_vsuffix(dummy_file):
-	"""Test setting the name and version suffix manually"""
+    """Test setting the name and version suffix manually"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/my_second_dataset",
-		"0.0.1",
-		"user",
-		None,
-		"This is my first DESC dataset",
-		name="custom name",
-		version_suffix="custom_suffix",
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/my_second_dataset",
+        "0.0.1",
+        "user",
+        None,
+        "This is my first DESC dataset",
+        name="custom name",
+        version_suffix="custom_suffix",
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        ["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.name") == "custom name"
-		assert getattr(r, "dataset.version_suffix") == "custom_suffix"
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.name") == "custom name"
+        assert getattr(r, "dataset.version_suffix") == "custom_suffix"
+        assert i < 1
 
 
 @pytest.mark.parametrize(
-	"v_type,ans,name",
-	[
-		("major", "1.0.0", "my_first_dataset"),
-		("minor", "0.1.0", "my_first_dataset"),
-		("patch", "0.0.2", "my_first_dataset"),
-		("patch", "0.0.1", "my_second_dataset"),
-	],
+    "v_type,ans,name",
+    [
+        ("major", "1.0.0", "my_first_dataset"),
+        ("minor", "0.1.0", "my_first_dataset"),
+        ("patch", "0.0.2", "my_first_dataset"),
+        ("patch", "0.0.1", "my_second_dataset"),
+    ],
 )
 def test_dataset_bumping(dummy_file, v_type, ans, name):
-	"""
-	Test bumping a dataset and make sure the new version is correct.
+    """
+    Test bumping a dataset and make sure the new version is correct.
 
-	Tests bumping datasets with and without a version suffix.
-	"""
+    Tests bumping datasets with and without a version suffix.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		f"DESC/datasets/bumped_dataset_{v_type}_{name}",
-		v_type,
-		"user",
-		None,
-		"This is my first bumped DESC dataset",
-		name=name,
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        f"DESC/datasets/bumped_dataset_{v_type}_{name}",
+        v_type,
+        "user",
+        None,
+        "This is my first bumped DESC dataset",
+        name=name,
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        ["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.name") == name
-		assert getattr(r, "dataset.version_string") == ans
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.name") == name
+        assert getattr(r, "dataset.version_string") == ans
+        assert i < 1
 
 
 @pytest.mark.parametrize("owner_type", ["user", "group", "project"])
 def test_owner_types(dummy_file, owner_type):
-	"""Test the different owner types"""
+    """Test the different owner types"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		f"DESC/datasets/owner_type_{owner_type}",
-		"0.0.1",
-		owner_type,
-		None,
-		f"This is a {owner_type} dataset",
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        f"DESC/datasets/owner_type_{owner_type}",
+        "0.0.1",
+        owner_type,
+        None,
+        f"This is a {owner_type} dataset",
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		["dataset.owner_type"], [f], return_format="cursorresult"
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        ["dataset.owner_type"], [f], return_format="cursorresult"
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.owner_type") == owner_type
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.owner_type") == owner_type
+        assert i < 1
 
 
 @pytest.mark.parametrize("data_org", ["file", "directory"])
 def test_copy_data(dummy_file, data_org):
-	"""Test copying real data into the registry (from an `old_location`)"""
+    """Test copying real data into the registry (from an `old_location`)"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# File/directory we are copying in
-	if data_org == "file":
-		data_path = str(tmp_src_dir / "file1.txt")
-	else:
-		data_path = str(tmp_src_dir / "directory1")
+    # File/directory we are copying in
+    if data_org == "file":
+        data_path = str(tmp_src_dir / "file1.txt")
+    else:
+        data_path = str(tmp_src_dir / "directory1")
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		f"DESC/datasets/copy_real_{data_org}",
-		"0.0.1",
-		"user",
-		None,
-		"Test copying a real file",
-		old_location=data_path,
-		is_dummy=False,
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        f"DESC/datasets/copy_real_{data_org}",
+        "0.0.1",
+        "user",
+        None,
+        "Test copying a real file",
+        old_location=data_path,
+        is_dummy=False,
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		["dataset.data_org", "dataset.nfiles", "dataset.total_disk_space"],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        ["dataset.data_org", "dataset.nfiles", "dataset.total_disk_space"],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.data_org") == data_org
-		assert getattr(r, "dataset.nfiles") == 1
-		assert getattr(r, "dataset.total_disk_space") > 0
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.data_org") == data_org
+        assert getattr(r, "dataset.nfiles") == 1
+        assert getattr(r, "dataset.total_disk_space") > 0
+        assert i < 1
 
 
 @pytest.mark.parametrize(
-	"data_org,data_path,v_str,overwritable",
-	[
-		("file", "file1.txt", "0.0.1", True),
-		("file", "file1.txt", "0.0.2", False),
-		("directory", "dummy_dir", "0.0.1", True),
-		("directory", "dummy_dir", "0.0.2", False),
-	],
+    "data_org,data_path,v_str,overwritable",
+    [
+        ("file", "file1.txt", "0.0.1", True),
+        ("file", "file1.txt", "0.0.2", False),
+        ("directory", "dummy_dir", "0.0.1", True),
+        ("directory", "dummy_dir", "0.0.2", False),
+    ],
 )
 def test_on_location_data(dummy_file, data_org, data_path, v_str, overwritable):
-	"""
-	Test ingesting real data into the registry (already on location). Also
-	tests overwriting datasets.
+    """
+    Test ingesting real data into the registry (already on location). Also
+    tests overwriting datasets.
 
-	Does twice for each file, the first is a normal entry with
-	`is_overwritable=True`. The second tests overwriting the previous data with
-	a new version.
-	"""
+    Does twice for each file, the first is a normal entry with
+    `is_overwritable=True`. The second tests overwriting the previous data with
+    a new version.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	d_id = _insert_dataset_entry(
-		datareg,
-		data_path,
-		v_str,
-		"user",
-		None,
-		"Test ingesting a real file on location",
-		old_location=None,
-		is_dummy=False,
-		is_overwritable=overwritable,
-	)
+    d_id = _insert_dataset_entry(
+        datareg,
+        data_path,
+        v_str,
+        "user",
+        None,
+        "Test ingesting a real file on location",
+        old_location=None,
+        is_dummy=False,
+        is_overwritable=overwritable,
+    )
 
-	f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.data_org",
-			"dataset.nfiles",
-			"dataset.total_disk_space",
-			"dataset.is_overwritable",
-			"dataset.is_overwritten",
-			"dataset.version_string",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.data_org",
+            "dataset.nfiles",
+            "dataset.total_disk_space",
+            "dataset.is_overwritable",
+            "dataset.is_overwritten",
+            "dataset.version_string",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	num_results = len(results.all())
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.data_org") == data_org
-		assert getattr(r, "dataset.nfiles") == 1
-		assert getattr(r, "dataset.total_disk_space") > 0
-		if getattr(r, "version_string") == "0.0.1":
-			if num_results == 1:
-				assert getattr(r, "dataset.is_overwritable") == True
-				assert getattr(r, "dataset.is_overwritten") == False
-			else:
-				assert getattr(r, "dataset.is_overwritable") == True
-				assert getattr(r, "dataset.is_overwritten") == True
-		else:
-			if num_results == 1:
-				assert getattr(r, "dataset.is_overwritable") == False
-				assert getattr(r, "dataset.is_overwritten") == True
-			else:
-				assert getattr(r, "dataset.is_overwritable") == False
-				assert getattr(r, "dataset.is_overwritten") == False
-		assert i < 2
+    num_results = len(results.all())
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.data_org") == data_org
+        assert getattr(r, "dataset.nfiles") == 1
+        assert getattr(r, "dataset.total_disk_space") > 0
+        if getattr(r, "version_string") == "0.0.1":
+            if num_results == 1:
+                assert getattr(r, "dataset.is_overwritable") == True
+                assert getattr(r, "dataset.is_overwritten") == False
+            else:
+                assert getattr(r, "dataset.is_overwritable") == True
+                assert getattr(r, "dataset.is_overwritten") == True
+        else:
+            if num_results == 1:
+                assert getattr(r, "dataset.is_overwritable") == False
+                assert getattr(r, "dataset.is_overwritten") == True
+            else:
+                assert getattr(r, "dataset.is_overwritable") == False
+                assert getattr(r, "dataset.is_overwritten") == False
+        assert i < 2
 
 
 def test_dataset_alias(dummy_file):
-	"""Register a dataset and make a dataset alias entry for it"""
+    """Register a dataset and make a dataset alias entry for it"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add dataset
-	d_id = _insert_dataset_entry(
-		datareg,
-		"alias_test_entry",
-		"0.0.1",
-		"user",
-		None,
-		"Test dataset alias",
-	)
+    # Add dataset
+    d_id = _insert_dataset_entry(
+        datareg,
+        "alias_test_entry",
+        "0.0.1",
+        "user",
+        None,
+        "Test dataset alias",
+    )
 
-	# Add alias
-	_insert_alias_entry(datareg, "nice_dataset_name", d_id)
+    # Add alias
+    _insert_alias_entry(datareg, "nice_dataset_name", d_id)
 
-	# Query
-	f = datareg.Query.gen_filter("dataset_alias.alias", "==", "nice_dataset_name")
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.dataset_id",
-			"dataset_alias.dataset_id",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset_alias.alias", "==", "nice_dataset_name")
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.dataset_id",
+            "dataset_alias.dataset_id",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.dataset_id") == d_id
-		assert getattr(r, "dataset_alias.dataset_id") == d_id
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.dataset_id") == d_id
+        assert getattr(r, "dataset_alias.dataset_id") == d_id
+        assert i < 1
 
 
 def test_pipeline_entry(dummy_file):
-	"""
-	Test making multiple executions and datasets to form a pipeline.
+    """
+    Test making multiple executions and datasets to form a pipeline.
 
-	Also queries to make sure dependencies are made.
-	"""
+    Also queries to make sure dependencies are made.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entries
-	ex_id_1 = _insert_execution_entry(
-		datareg, "pipeline_stage_1", "The first stage of my pipeline"
-	)
+    # Add entries
+    ex_id_1 = _insert_execution_entry(
+        datareg, "pipeline_stage_1", "The first stage of my pipeline"
+    )
 
-	d_id_1 = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/my_first_pipeline_stage1",
-		"0.0.1",
-		"user",
-		None,
-		"This is data for stage 1 of my first pipeline",
-		execution_id=ex_id_1,
-	)
+    d_id_1 = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/my_first_pipeline_stage1",
+        "0.0.1",
+        "user",
+        None,
+        "This is data for stage 1 of my first pipeline",
+        execution_id=ex_id_1,
+    )
 
-	ex_id_2 = _insert_execution_entry(
-		datareg,
-		"pipeline_stage_2",
-		"The second stage of my pipeline",
-		input_datasets=[d_id_1],
-	)
+    ex_id_2 = _insert_execution_entry(
+        datareg,
+        "pipeline_stage_2",
+        "The second stage of my pipeline",
+        input_datasets=[d_id_1],
+    )
 
-	d_id_2 = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/my_first_pipeline_stage2a",
-		"0.0.1",
-		"user",
-		None,
-		"This is data for stage 2 of my first pipeline",
-		execution_id=ex_id_2,
-	)
+    d_id_2 = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/my_first_pipeline_stage2a",
+        "0.0.1",
+        "user",
+        None,
+        "This is data for stage 2 of my first pipeline",
+        execution_id=ex_id_2,
+    )
 
-	d_id_3 = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/my_first_pipeline_stage2b",
-		"0.0.1",
-		"user",
-		None,
-		"This is data for stage 2 of my first pipeline",
-		execution_id=ex_id_2,
-	)
+    d_id_3 = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/my_first_pipeline_stage2b",
+        "0.0.1",
+        "user",
+        None,
+        "This is data for stage 2 of my first pipeline",
+        execution_id=ex_id_2,
+    )
 
-	# Stage 3 of my pipeline
-	ex_id_3 = _insert_execution_entry(
-		datareg,
-		"pipeline_stage_3",
-		"The third stage of my pipeline",
-		input_datasets=[d_id_2, d_id_3],
-	)
+    # Stage 3 of my pipeline
+    ex_id_3 = _insert_execution_entry(
+        datareg,
+        "pipeline_stage_3",
+        "The third stage of my pipeline",
+        input_datasets=[d_id_2, d_id_3],
+    )
 
-	# Query on execution
-	f = datareg.Query.gen_filter("dataset.execution_id", "==", ex_id_2)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.name",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query on execution
+    f = datareg.Query.gen_filter("dataset.execution_id", "==", ex_id_2)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.name",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert "my_first_pipeline_stage2" in getattr(r, "dataset.name")
-		assert i < 2
+    for i, r in enumerate(results):
+        assert "my_first_pipeline_stage2" in getattr(r, "dataset.name")
+        assert i < 2
 
-	# Query on dependency
-	f = datareg.Query.gen_filter("dependency.execution_id", "==", ex_id_2)
-	results = datareg.Query.find_datasets(
-		[
-			"dependency.execution_id",
-			"dataset.dataset_id",
-			"dataset.execution_id",
-			"dataset.name",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query on dependency
+    f = datareg.Query.gen_filter("dependency.execution_id", "==", ex_id_2)
+    results = datareg.Query.find_datasets(
+        [
+            "dependency.execution_id",
+            "dataset.dataset_id",
+            "dataset.execution_id",
+            "dataset.name",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.dataset_id") == d_id_1
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.dataset_id") == d_id_1
+        assert i < 1
 
 
 def test_global_owner_set(dummy_file):
-	"""
-	Test setting the owner and owner_type globally during the database
-	initialization.
-	"""
+    """
+    Test setting the owner and owner_type globally during the database
+    initialization.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(
-		root_dir=str(tmp_root_dir),
-		schema=SCHEMA_VERSION,
-		owner="DESC group",
-		owner_type="group",
-	)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(
+        root_dir=str(tmp_root_dir),
+        schema=SCHEMA_VERSION,
+        owner="DESC group",
+        owner_type="group",
+    )
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/global_user_dataset",
-		"0.0.1",
-		None,
-		None,
-		"Should be allocated user and user_type from global config",
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/global_user_dataset",
+        "0.0.1",
+        None,
+        None,
+        "Should be allocated user and user_type from global config",
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.owner",
-			"dataset.owner_type",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.owner",
+            "dataset.owner_type",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.owner") == "DESC group"
-		assert getattr(r, "dataset.owner_type") == "group"
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.owner") == "DESC group"
+        assert getattr(r, "dataset.owner_type") == "group"
+        assert i < 1
 
 
 @pytest.mark.skip(reason="Can't do production related things with sqlite")
 def test_prooduction_schema(dummy_file):
-	"""
-	Test making multiple executions and datasets to form a pipeline.
+    """
+    Test making multiple executions and datasets to form a pipeline.
 
-	Also queries to make sure dependencies are made.
-	"""
+    Also queries to make sure dependencies are made.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema="production")
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema="production")
 
-	d_id = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/production_dataset_1",
-		"0.0.1",
-		"production",
-		None,
-		"This is production's first dataset",
-	)
+    d_id = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/production_dataset_1",
+        "0.0.1",
+        "production",
+        None,
+        "This is production's first dataset",
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.owner",
-			"dataset.owner_type",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.owner",
+            "dataset.owner_type",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dataset.owner") == "production"
-		assert getattr(r, "dataset.owner_type") == "production"
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.owner") == "production"
+        assert getattr(r, "dataset.owner_type") == "production"
+        assert i < 1
 
 
 def test_execution_config_file(dummy_file):
-	"""Test ingesting a configuration file with an execution entry"""
+    """Test ingesting a configuration file with an execution entry"""
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Add entry
-	ex_id = _insert_execution_entry(
-		datareg,
-		"execution_with_configuration",
-		"An execution with an input configuration file",
-		configuration=str(tmp_src_dir / "dummy_configuration_file.yaml"),
-	)
+    # Add entry
+    ex_id = _insert_execution_entry(
+        datareg,
+        "execution_with_configuration",
+        "An execution with an input configuration file",
+        configuration=str(tmp_src_dir / "dummy_configuration_file.yaml"),
+    )
 
-	# Query
-	f = datareg.Query.gen_filter("execution.execution_id", "==", ex_id)
-	results = datareg.Query.find_datasets(
-		[
-			"execution.configuration",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query
+    f = datareg.Query.gen_filter("execution.execution_id", "==", ex_id)
+    results = datareg.Query.find_datasets(
+        [
+            "execution.configuration",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "execution.configuration") is not None
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "execution.configuration") is not None
+        assert i < 1
 
 
 def test_dataset_with_execution(dummy_file):
-	"""
-	Test modifying the datasets default execution directly when registering the
-	dataset
-	"""
+    """
+    Test modifying the datasets default execution directly when registering the
+    dataset
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	d_id_1 = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/execution_test_input",
-		"0.0.1",
-		None,
-		None,
-		"This is production's first dataset",
-	)
+    d_id_1 = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/execution_test_input",
+        "0.0.1",
+        None,
+        None,
+        "This is production's first dataset",
+    )
 
-	d_id_2 = _insert_dataset_entry(
-		datareg,
-		"DESC/datasets/execution_test",
-		"0.0.1",
-		None,
-		None,
-		"This should have a more descriptive execution",
-		execution_name="Overwrite execution auto name",
-		execution_description="Overwrite execution auto description",
-		execution_locale="TestMachine",
-		input_datasets=[d_id_1],
-	)
+    d_id_2 = _insert_dataset_entry(
+        datareg,
+        "DESC/datasets/execution_test",
+        "0.0.1",
+        None,
+        None,
+        "This should have a more descriptive execution",
+        execution_name="Overwrite execution auto name",
+        execution_description="Overwrite execution auto description",
+        execution_locale="TestMachine",
+        input_datasets=[d_id_1],
+    )
 
-	# Query on execution
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id_2)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.name",
-			"execution.execution_id",
-			"execution.description",
-			"execution.locale",
-			"execution.name",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query on execution
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id_2)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.name",
+            "execution.execution_id",
+            "execution.description",
+            "execution.locale",
+            "execution.name",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "execution.name") == "Overwrite execution auto name"
-		assert (
-			getattr(r, "execution.description")
-			== "Overwrite execution auto description"
-		)
-		assert getattr(r, "execution.locale") == "TestMachine"
-		ex_id_1 = getattr(r, "execution.execution_id")
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "execution.name") == "Overwrite execution auto name"
+        assert (
+            getattr(r, "execution.description")
+            == "Overwrite execution auto description"
+        )
+        assert getattr(r, "execution.locale") == "TestMachine"
+        ex_id_1 = getattr(r, "execution.execution_id")
+        assert i < 1
 
-	# Query on dependency
-	f = datareg.Query.gen_filter("dependency.input_id", "==", d_id_1)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.dataset_id",
-			"dependency.execution_id",
-			"dependency.input_id",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Query on dependency
+    f = datareg.Query.gen_filter("dependency.input_id", "==", d_id_1)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.dataset_id",
+            "dependency.execution_id",
+            "dependency.input_id",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for i, r in enumerate(results):
-		assert getattr(r, "dependency.execution_id") == ex_id_1
-		assert i < 1
+    for i, r in enumerate(results):
+        assert getattr(r, "dependency.execution_id") == ex_id_1
+        assert i < 1
 
 
 def test_get_dataset_absolute_path(dummy_file):
-	"""
-	Test the generation of the full absolute path of a dataset using the
-	`Query.get_dataset_absolute_path` function
-	"""
+    """
+    Test the generation of the full absolute path of a dataset using the
+    `Query.get_dataset_absolute_path` function
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	dset_relpath = "DESC/datasets/get_dataset_absolute_path_test"
-	dset_ownertype = "group"
-	dset_owner = "group1"
+    dset_relpath = "DESC/datasets/get_dataset_absolute_path_test"
+    dset_ownertype = "group"
+    dset_owner = "group1"
 
-	# Make a basic entry
-	d_id_1 = _insert_dataset_entry(
-		datareg,
-		dset_relpath,
-		"0.0.1",
-		dset_ownertype,
-		dset_owner,
-		"Test the Query.get_dataset_absolute_path function",
-	)
+    # Make a basic entry
+    d_id_1 = _insert_dataset_entry(
+        datareg,
+        dset_relpath,
+        "0.0.1",
+        dset_ownertype,
+        dset_owner,
+        "Test the Query.get_dataset_absolute_path function",
+    )
 
-	v = datareg.Query.get_dataset_absolute_path(d_id_1)
+    v = datareg.Query.get_dataset_absolute_path(d_id_1)
 
-	if datareg.Query._dialect == "sqlite":
-		assert v == os.path.join(
-			str(tmp_root_dir), dset_ownertype, dset_owner, dset_relpath
-		)
-	else:
-		assert v == os.path.join(
-			str(tmp_root_dir), SCHEMA_VERSION, dset_ownertype, dset_owner, dset_relpath
-		)
+    if datareg.Query._dialect == "sqlite":
+        assert v == os.path.join(
+            str(tmp_root_dir), dset_ownertype, dset_owner, dset_relpath
+        )
+    else:
+        assert v == os.path.join(
+            str(tmp_root_dir), SCHEMA_VERSION, dset_ownertype, dset_owner, dset_relpath
+        )
 
 @pytest.mark.parametrize(
-	"is_dummy,dataset_name",
-	[
-		(True, "dummy_dataset_to_delete"),
-		(False, "real_dataset_to_delete"),
-	],
+    "is_dummy,dataset_name",
+    [
+        (True, "dummy_dataset_to_delete"),
+        (False, "real_dataset_to_delete"),
+    ],
 )
 def test_delete_entry(dummy_file, is_dummy, dataset_name):
-	"""
-	Make a simple entry, then delete it, then check it was deleted.
+    """
+    Make a simple entry, then delete it, then check it was deleted.
 
-	Does this for a dummy dataset and a real one.
-	"""
+    Does this for a dummy dataset and a real one.
+    """
 
-	# Establish connection to database
-	tmp_src_dir, tmp_root_dir = dummy_file
-	datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-	# Make sure we raise an exception trying to delete a dataset that doesn't exist
-	with pytest.raises(ValueError, match="does not exist"):
-		datareg.Registrar.dataset.delete(10000)
+    # Make sure we raise an exception trying to delete a dataset that doesn't exist
+    with pytest.raises(ValueError, match="does not exist"):
+        datareg.Registrar.dataset.delete(10000)
 
-	# Where is the real data?
-	if is_dummy:
-		data_path = None
-	else:
-		data_path = str(tmp_src_dir / "file2.txt")
-		assert os.path.isfile(data_path)
+    # Where is the real data?
+    if is_dummy:
+        data_path = None
+    else:
+        data_path = str(tmp_src_dir / "file2.txt")
+        assert os.path.isfile(data_path)
 
-	# Add entry
-	d_id = _insert_dataset_entry(
-		datareg,
-		f"DESC/datasets/{dataset_name}",
-		"0.0.1",
-		"user",
-		None,
-		"A dataset to delete",
-		is_dummy=is_dummy,
-		old_location=data_path,
-	)
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg,
+        f"DESC/datasets/{dataset_name}",
+        "0.0.1",
+        "user",
+        None,
+        "A dataset to delete",
+        is_dummy=is_dummy,
+        old_location=data_path,
+    )
 
-	# Now delete that entry
-	datareg.Registrar.dataset.delete(d_id)
+    # Now delete that entry
+    datareg.Registrar.dataset.delete(d_id)
 
-	# Check the entry was deleted
-	f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
-	results = datareg.Query.find_datasets(
-		[
-			"dataset.status",
-			"dataset.delete_date",
-			"dataset.delete_uid",
-			"dataset.owner_type",
-			"dataset.owner",
-			"dataset.relative_path",
-		],
-		[f],
-		return_format="cursorresult",
-	)
+    # Check the entry was deleted
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.status",
+            "dataset.delete_date",
+            "dataset.delete_uid",
+            "dataset.owner_type",
+            "dataset.owner",
+            "dataset.relative_path",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
 
-	for r in results:
-		assert getattr(r, "dataset.status") == 3
-		assert getattr(r, "dataset.delete_date") is not None
-		assert getattr(r, "dataset.delete_uid") is not None
+    for r in results:
+        assert get_dataset_status(getattr(r, "dataset.status"), "deleted")
+        assert getattr(r, "dataset.delete_date") is not None
+        assert getattr(r, "dataset.delete_uid") is not None
 
-	if not is_dummy:
-		# Make sure the file in the root_dir has gone
-		data_path = _form_dataset_path(
-			getattr(r, "dataset.owner_type"),
-			getattr(r, "dataset.owner"),
-			getattr(r, "dataset.relative_path"),
-			schema=SCHEMA_VERSION,
-			root_dir=str(tmp_root_dir),
-		)
-		assert not os.path.isfile(data_path)
+    if not is_dummy:
+        # Make sure the file in the root_dir has gone
+        data_path = _form_dataset_path(
+            getattr(r, "dataset.owner_type"),
+            getattr(r, "dataset.owner"),
+            getattr(r, "dataset.relative_path"),
+            schema=SCHEMA_VERSION,
+            root_dir=str(tmp_root_dir),
+        )
+        assert not os.path.isfile(data_path)
 
-	# Make sure we can not delete an already deleted entry.
-	with pytest.raises(ValueError, match="not have a valid status"):
-		datareg.Registrar.dataset.delete(d_id)
+    # Make sure we can not delete an already deleted entry.
+    with pytest.raises(ValueError, match="not have a valid status"):
+        datareg.Registrar.dataset.delete(d_id)


### PR DESCRIPTION
Can now delete datasets using `Registrar.dataset.delete(<dataset_id>)`.

Function :
- Checks the dataset exists, and that it is a "valid" (0 or 1) status
- Changes the status to `3` and sets the `delete_date` and `delete_uid` fields
- Deletes the data in the `root_dir`

Have added unit tests to make sure these things are happening

(Had to modify the `previous_dataset` function to be used also to search on `dataset_id` for this function to also use)