### PR TITLE
Raise error if dataset with version suffix gets auto bumped

### DIFF
--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -168,10 +168,8 @@ class DatasetTable(BaseTable):
             version_string = version
         else:
             # Generate new version fields based on previous entries
-            # with the same name field and same suffix (i.e., bump)
-            v_fields = _bump_version(
-                name, version, version_suffix, dataset_table, self._engine
-            )
+            # with the same name field (i.e., bump)
+            v_fields = _bump_version(name, version, dataset_table, self._engine)
             version_string = (
                 f"{v_fields['major']}.{v_fields['minor']}.{v_fields['patch']}"
             )

--- a/tests/end_to_end_tests/test_end_to_end_python_api.py
+++ b/tests/end_to_end_tests/test_end_to_end_python_api.py
@@ -325,14 +325,28 @@ def test_manual_name_and_vsuffix(dummy_file):
         assert getattr(r, "dataset.version_suffix") == "custom_suffix"
         assert i < 1
 
+    # Try to bump dataset with version suffix (should fail)
+    with pytest.raises(ValueError, match="Cannot bump"):
+        d_id = _insert_dataset_entry(
+            datareg,
+            "DESC/datasets/my_second_dataset_bumped",
+            "major",
+            "user",
+            None,
+            "This is my first DESC dataset",
+            name="custom name",
+        )
+
 
 @pytest.mark.parametrize(
     "v_type,ans,name",
     [
         ("major", "1.0.0", "my_first_dataset"),
-        ("minor", "0.1.0", "my_first_dataset"),
-        ("patch", "0.0.2", "my_first_dataset"),
-        ("patch", "0.0.1", "my_second_dataset"),
+        ("minor", "1.1.0", "my_first_dataset"),
+        ("patch", "1.1.1", "my_first_dataset"),
+        ("patch", "1.1.2", "my_first_dataset"),
+        ("minor", "1.2.0", "my_first_dataset"),
+        ("major", "2.0.0", "my_first_dataset"),
     ],
 )
 def test_dataset_bumping(dummy_file, v_type, ans, name):
@@ -349,7 +363,7 @@ def test_dataset_bumping(dummy_file, v_type, ans, name):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/bumped_dataset_{v_type}_{name}",
+        f"DESC/datasets/bumped_dataset_{v_type}_{name}_{ans.replace('.','_')}",
         v_type,
         "user",
         None,


### PR DESCRIPTION
Decided we do not want to deal with how do auto-bump a dataset that has a suffix.

Therefore if the user tries to auto-bump a dataset with a suffix an error is raised.

A user can work with version suffixes and bumping manually, when registering the updated dataset they specify the version and suffix manually rather than trying to auto bump.