### PR TITLE
Add ability to delete datasets with CLI

### DIFF
--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -9,7 +9,7 @@ from dataregistry.schema import load_schema
 
 def _add_generic_arguments(parser_obj):
     """
-    Most commands have the schema/root_dir/etc as options, have a function that
+    Most commands have the schema, root_dir, etc. as options. This function
     does that for us.
 
     Parameters

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -3,8 +3,33 @@ import sys
 import argparse
 from dataregistry.db_basic import SCHEMA_VERSION
 from .register import register_dataset
+from .delete import delete_dataset
 from .query import dregs_ls
 from dataregistry.schema import load_schema
+
+def _add_generic_arguments(parser_obj):
+    """
+    Most commands have the schema/root_dir/etc as options, have a function that
+    does that for us.
+
+    Parameters
+    ----------
+    parser_obj : argparse.ArgumentParser
+        Argument parser we are adding the options to
+    """
+
+    parser_obj.add_argument(
+        "--config_file", help="Location of data registry config file", type=str
+    )
+    parser_obj.add_argument("--root_dir", help="Location of the root_dir", type=str)
+    parser_obj.add_argument(
+        "--site", help="Get the root_dir through a pre-defined 'site'", type=str
+    )
+    parser_obj.add_argument(
+        "--schema",
+        default=f"{SCHEMA_VERSION}",
+        help="Which schema to connect to",
+    )
 
 def get_parser():
 
@@ -30,23 +55,12 @@ def get_parser():
         help="List datasets for a given owner type",
         choices=["user", "group", "production"],
     )
-    arg_ls.add_argument(
-        "--config_file", help="Location of data registry config file", type=str
-    )
     arg_ls.add_argument("--all", help="List all datasets", action="store_true")
-    arg_ls.add_argument(
-        "--schema",
-        default=f"{SCHEMA_VERSION}",
-        help="Which schema to connect to",
-    )
-    arg_ls.add_argument("--root_dir", help="Location of the root_dir", type=str)
-    arg_ls.add_argument(
-        "--site", help="Get the root_dir through a pre-defined 'site'", type=str
-    )
-    
-    # ------------------
-    # Register a dataset
-    # ------------------
+    _add_generic_arguments(arg_ls)
+
+    # --------
+    # Register
+    # --------
     
     # Load the schema information (help strings are loaded from here)
     schema_data = load_schema()
@@ -70,7 +84,11 @@ def get_parser():
     arg_register_sub = arg_register.add_subparsers(
         title="register what?", dest="register_type"
     )
-    
+   
+    # ------------------
+    # Register a dataset
+    # ------------------
+
     # Register a new dataset.
     arg_register_dataset = arg_register_sub.add_parser("dataset", help="Register a dataset")
     
@@ -141,14 +159,6 @@ def get_parser():
         action="store_true",
     )
     arg_register_dataset.add_argument(
-        "--schema",
-        default=f"{SCHEMA_VERSION}",
-        help="Which schema to connect to",
-    )
-    arg_register_dataset.add_argument(
-        "--config_file", help="Location of data registry config file", type=str
-    )
-    arg_register_dataset.add_argument(
         "--execution_name", help="Typically pipeline name or program name", type=str
     )
     arg_register_dataset.add_argument(
@@ -172,12 +182,30 @@ def get_parser():
         default=[],
         nargs="+",
     )
-    arg_register_dataset.add_argument(
-        "--root_dir", help="Location of the root_dir", type=str
+    _add_generic_arguments(arg_register_dataset)
+
+    # ------
+    # Delete
+    # ------
+    
+    # Register a new database entry.
+    arg_delete = subparsers.add_parser(
+        "delete", help="Delete an entry in the database"
     )
-    arg_register_dataset.add_argument(
-        "--site", help="Get the root_dir through a pre-defined 'site'", type=str
+    
+    arg_delete_sub = arg_delete.add_subparsers(
+        title="delete what?", dest="delete_type"
     )
+
+    # ----------------
+    # Delete a dataset
+    # ----------------
+
+    # Delete a dataset.
+    arg_delete_dataset = arg_delete_sub.add_parser("dataset", help="Delete a dataset")
+    arg_delete_dataset.add_argument("dataset_id", help="The dataset_id you wish to delete",
+            type=int)
+    _add_generic_arguments(arg_delete_dataset)
 
     return parser
 
@@ -203,6 +231,11 @@ def main(cmd=None):
     if args.subcommand == "register":
         if args.register_type == "dataset":
             register_dataset(args)
+
+    # Delete an entry
+    elif args.subcommand == "delete":
+        if args.delete_type == "dataset":
+            delete_dataset(args)
 
     # Query database entries
     elif args.subcommand == "ls":

--- a/src/dataregistry_cli/delete.py
+++ b/src/dataregistry_cli/delete.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+import os
+from dataregistry import DataRegistry
+
+
+def delete_dataset(args):
+    """
+    Delete a dataset in the DESC data registry.
+
+    Parameters
+    ----------
+    args : argparse object
+
+    args.config_file : str
+        Path to data registry config file
+    args.schema : str
+        Which schema to search
+    args.root_dir : str
+        Path to root_dir
+    args.site : str
+        Look up root_dir using a site
+
+    args.dataset_id: int
+        The dataset_id of the dataset we are deleting
+    """
+
+    # Connect to database.
+    datareg = DataRegistry(
+        config_file=args.config_file,
+        schema=args.schema,
+        root_dir=args.root_dir,
+        site=args.site,
+    )
+
+    datareg.Registrar.dataset.delete(args.dataset_id)

--- a/src/dataregistry_cli/query.py
+++ b/src/dataregistry_cli/query.py
@@ -71,15 +71,14 @@ def dregs_ls(args):
     else:
         print("all datasets", end=" ")
 
-    # Show the format out the output.
-    mystr = "Format : '[owner_type:owner] name : version_string -> relative_path'"
-    print(f"\n{mystr}")
-    print("-" * len(mystr))
-
     # Loop over this schema and the production schema and print the results
     for this_datareg in [datareg, datareg_prod]:
         if this_datareg is None:
             continue
+    
+        mystr = f"Schema = {this_datareg.db_connection.schema}"
+        print(f"\n{mystr}")
+        print("-" * len(mystr))
 
         # Query
         results = this_datareg.Query.find_datasets(
@@ -89,21 +88,10 @@ def dregs_ls(args):
                 "dataset.relative_path",
                 "dataset.owner",
                 "dataset.owner_type",
+                "dataset.status",
             ],
             filters,
-            return_format="CursorResult",
+            return_format="dataframe",
         )
 
-        # Loop over each result and print.
-        if results.rowcount > 0:
-            for r in results:
-                tmp_name = getattr(r, "dataset.name")
-                tmp_vs = getattr(r, "dataset.version_string")
-                tmp_path = getattr(r, "dataset.relative_path")
-                tmp_owner = getattr(r, "dataset.owner")
-                tmp_owner_type = getattr(r, "dataset.owner_type")
-
-                print(
-                    f" - [{tmp_owner_type}:{tmp_owner}] {tmp_name} :",
-                    f"v{tmp_vs} -> {tmp_path}",
-                )
+        print(results.to_string(index=False))

--- a/tests/end_to_end_tests/test_end_to_end_cli.py
+++ b/tests/end_to_end_tests/test_end_to_end_cli.py
@@ -1,9 +1,12 @@
-import dataregistry_cli.cli as cli
-from dataregistry.db_basic import SCHEMA_VERSION
-from dataregistry import DataRegistry
 import shlex
-from test_end_to_end_python_api import dummy_file
+
+import dataregistry_cli.cli as cli
 import pytest
+from dataregistry import DataRegistry
+from dataregistry.db_basic import SCHEMA_VERSION
+from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
+
+from test_end_to_end_python_api import dummy_file
 
 
 def test_simple_query(dummy_file):
@@ -88,3 +91,45 @@ def test_production_entry(dummy_file):
         )
         assert len(results["dataset.name"]) == 1, "Bad result from query dcli3"
         assert results["dataset.version_string"][0] == "0.1.2"
+
+
+def test_delete_dataset(dummy_file):
+    """Make a simple entry, then delete it"""
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+
+    # Register a dataset
+    cmd = "register dataset my_cli_dataset_to_delete 0.0.1 --is_dummy"
+    cmd += f" --schema {SCHEMA_VERSION} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+
+    # Find the dataset id
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_delete")
+    results = datareg.Query.find_datasets(["dataset.dataset_id"], [f])
+    assert len(results["dataset.dataset_id"]) == 1, "Bad result from query dcli4"
+    d_id = results["dataset.dataset_id"][0]
+
+    # Delete the dataset
+    cmd = f"delete dataset {d_id}"
+    cmd += f" --schema {SCHEMA_VERSION} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+
+    # Check
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+    f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_delete")
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.dataset_id",
+            "dataset.delete_date",
+            "dataset.delete_uid",
+            "dataset.status",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
+    for r in results:
+        assert get_dataset_status(getattr(r, "dataset.status"), "deleted")
+        assert getattr(r, "dataset.delete_date") is not None
+        assert getattr(r, "dataset.delete_uid") is not None


### PR DESCRIPTION
Changes:
- Add ability to delete datasets using the CLI with `dregs delete dataset <dataset_id>`
- Added CI test in `test_end_to_end_cli.py` that creates a dataset using the CLI, then deletes it.
- Update `dregs ls` to also show the `dataset.status` field (might want to make showing delete datasets optional in the future)