### PR TITLE
Don't overwrite the schema_yaml dict entries during database creation

### DIFF
--- a/scripts/create_registry_db.py
+++ b/scripts/create_registry_db.py
@@ -65,15 +65,16 @@ def _get_column_definitions(schema, table):
     for column in schema_yaml[table].keys():
         # Special case where column has a foreign key
         if schema_yaml[table][column]["foreign_key"]:
-            if schema_yaml[table][column]["foreign_key_schema"] == "self":
-                schema_yaml[table][column]["foreign_key_schema"] = schema
+            fk_schema = schema
+            if schema_yaml[table][column]["foreign_key_schema"] != "self":
+                fk_schema = schema_yaml[table][column]["foreign_key_schema"]
 
             return_dict[column] = Column(
                 column,
                 _TYPE_TRANSLATE[schema_yaml[table][column]["type"]],
                 ForeignKey(
                     _get_ForeignKey_str(
-                        schema_yaml[table][column]["foreign_key_schema"],
+                        fk_schema,
                         schema_yaml[table][column]["foreign_key_table"],
                         schema_yaml[table][column]["foreign_key_column"],
                     )


### PR DESCRIPTION
Was accidentally overwriting the schema yaml file entries for the foreign keys.

Because we loop over the default and production schema, the entries were corrupt on the 2nd itteration. 