### PR TITLE
Input ID bug when creating executions 

### DIFF
--- a/src/dataregistry/registrar/execution.py
+++ b/src/dataregistry/registrar/execution.py
@@ -81,12 +81,14 @@ class ExecutionTable(BaseTable):
             for d in input_datasets:
                 values["register_date"] = datetime.now()
                 values["input_id"] = d
+                values["input_production_id"] = None
                 values["execution_id"] = my_id
                 add_table_row(conn, dependency_table, values, commit=False)
 
             # handle production dependencies
             for d in input_production_datasets:
                 values["register_date"] = datetime.now()
+                values["input_id"] = None
                 values["input_production_id"] = d
                 values["execution_id"] = my_id
                 add_table_row(conn, dependency_table, values, commit=False)


### PR DESCRIPTION
When creating executions with input datasets from both the production and standard schema the `values` dict would have left over entries in the `input_id` of the `input_production_id` from the other schema.

The `input_production_id` for standard dependencies should be `None`, and vice versa for the production schema.

Now explicitly reset the non-used input ID in the `values` dict each time. 