### PR TITLE
Swap `name` and `relative_path` as the mandatory entry

### DIFF
--- a/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
+++ b/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
@@ -25,7 +25,8 @@
     "4) Modify a previously registered dataset with updated metadata\n",
     "5) Delete a dataset\n",
     "6) Special cases\n",
-    "    * Registering external datasets \n",
+    "    * Registering external datasets\n",
+    "    * Manually specifying the relative path\n",
     "\n",
     "### Before we begin\n",
     "\n",
@@ -166,7 +167,7 @@
     "\n",
     "# Add new entry.\n",
     "dataset_id, execution_id = datareg.Registrar.dataset.register(\n",
-    "    \"nersc_tutorial/my_desc_dataset\",\n",
+    "    \"nersc_tutorial:my_desc_dataset\",\n",
     "    \"1.0.0\",\n",
     "    description=\"An output from some DESC code\",\n",
     "    owner=\"DESC\",\n",
@@ -191,13 +192,11 @@
    "source": [
     "This will register a new dataset. A few notes:\n",
     "\n",
-    "### The relative path\n",
+    "### The dataset name (mandatory)\n",
     "\n",
-    "Datasets are registered within the registry under a path relative to the root directory (`root_dir`), which, by default, is a shared space at NERSC. For those interested, the eventual full path for the dataset will be `<root_dir>/<schema>/<owner_type>/<owner>/<relative_path>`. This means that the combination of `relative_path`, `owner` and `owner_type` must be unique within the registry, and therefore cannot already be taken when you register a new dataset (an exception to this is if you allow your datasets to be overwritable, see below). \n",
+    "The first of two mandatory arguments to the `register()` function is the dataset `name`, which in our example is `nersc_tutorial:my_desc_dataset` (note there is nothing special about the `:` here, the `name` can be any legal string). This should be any convenient, evocative name for the human. Note the combination of `name`, `version` and `version_suffix` must be unique in the database. The dataset `name` allows for an easy retrieval of the dataset for querying and updating.\n",
     "\n",
-    "The relative path is one of the two required parameters you must specify when registering a dataset (in the example here our relative path is `nersc_tutorial/my_desc_dataset`).\n",
-    "\n",
-    "### The version string\n",
+    "### The version string (mandatory)\n",
     "\n",
     "The second required parameter is the version string, in the semantic format, i.e., MAJOR.MINOR.PATCH. There exists also an optional ``version_suffix`` parameter, which may be used to further identify the dataset, e.g. with a value like \"rc1\" to make it clear it's only a release candidate, possibly not in its final form.\n",
     "\n",
@@ -238,15 +237,13 @@
     "\n",
     "If you have a dataset that has been previously registered within the data registry, and that dataset has updates, you have three options for how to handle the new entry:\n",
     "\n",
-    "- You can enter it as a completely new standalone dataset with no links to the previous dataset\n",
-    "- You can overwrite the existing dataset with the new data (only if the previous dataset was entered with `is_overwritable=True`)\n",
-    "- You can enter it as a new version of the previous dataset (recommended)\n",
+    "1. You can enter it as a completely new standalone dataset with no links to the previous dataset\n",
+    "2. You can enter it as a new version of the previous dataset (recommended)\n",
+    "3. You can overwrite the existing dataset with the new data (only if the previous dataset was entered with `is_overwritable=True`)\n",
     "\n",
-    "Unless you are overwriting a previous dataset (when `is_overwritable=True`), you cannot enter a new dataset (even an updated version) using the same relative path. However, datasets can share the same `name` field, which acts as a reference for the dataset, and which is what we'll use to keep our updated dataset connected to our previous one.\n",
+    "For 1. simply follow the procedure above for registering a new dataset.\n",
     "\n",
-    "Note that for our test dataset entry above we did not specify a `name` during registration. The default `name` for a dataset is the file or directory name, extracted from the relative path. In our example above this was `my_desc_dataset`. If you are unsure of what name you specified for your previous dataset that you want to overwrite, you will need to query the database first to find out (see next tutorial for queries).\n",
-    "\n",
-    "The combination of `name`, `version` and `version_suffix` for any dataset must be unique. As we are updating a dataset with the same name, we have to make sure to update the version to a new value. One handy feature is automatic version \"bumping\" for datasets, i.e., rather than specifying a new version string manually, one can select \"major\", \"minor\" or \"patch\" for the version string to automatically bump that property of the version string up. In our case, selecting \"minor\" will automatically generate the version \"1.1.0\"."
+    "For 2. we register a new dataset as before, making sure to keep the same dataset `name`, but updating the dataset `version`. One can update the `version` in two ways: manually entering a new version string, or having the `dataregistry` automatically \"bump\" the dataset version by selecing either \"major\", \"minor\" or \"patch\" for the version string. For example, lets register an updated version of our dataset, bumping the minor tag (i.e., bumping `1.0.0` -> `1.1.0`)."
    ]
   },
   {
@@ -258,14 +255,17 @@
    },
    "outputs": [],
    "source": [
+    "# Create an empty text file as some example data\n",
+    "with open(\"updated_dummy_dataset.txt\", \"w\") as f:\n",
+    "    f.write(\"some updated data\")\n",
+    "\n",
     "# Add new entry for an updated dataset with an updated version.\n",
     "updated_dataset_id, updated_execution_id = datareg.Registrar.dataset.register(\n",
-    "    \"nersc_tutorial/my_updated_desc_dataset\",\n",
+    "    \"nersc_tutorial:my_desc_dataset\",\n",
     "    \"minor\", # Automatically bumps to \"1.1.0\"\n",
     "    description=\"An output from some DESC code (updated)\",\n",
     "    is_overwritable=True,\n",
-    "    old_location=\"dummy_dataset.txt\",\n",
-    "    name=\"my_desc_dataset\" # Using this name links it to the previous dataset.\n",
+    "    old_location=\"updated_dummy_dataset.txt\",\n",
     ")\n",
     "\n",
     "# This is the unique identifier assigned to the updated dataset from the registry\n",
@@ -273,6 +273,52 @@
     "\n",
     "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
     "print(f\"Dataset assigned to execution {updated_execution_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60f1bbb-adcb-4847-9e65-d8d14d928041",
+   "metadata": {},
+   "source": [
+    "Note that both sets of data, from version `1.0.0` and `1.1.0` still exist, and they are linked through the dataset `name`.\n",
+    "\n",
+    "For 3., to update a previous dataset and overwrite the existing data, we have the pass the `relative_path` of the existing dataset (see Section 6 for more details on the `relative_path`). For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2494eeea-b53f-472b-aafd-88216cb36494",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an empty text file as some example data\n",
+    "with open(\"updated_dummy_dataset_again.txt\", \"w\") as f:\n",
+    "    f.write(\"some further updated data\")\n",
+    "\n",
+    "# Add new entry for an updated dataset with an updated version.\n",
+    "updated_dataset_id, updated_execution_id = datareg.Registrar.dataset.register(\n",
+    "    \"nersc_tutorial:my_desc_dataset\",\n",
+    "    \"patch\", # Automatically bumps to \"1.1.1\"\n",
+    "    description=\"An output from some DESC code (further updated)\",\n",
+    "    is_overwritable=True,\n",
+    "    old_location=\"updated_dummy_dataset_again.txt\",\n",
+    "    relative_path=\"nersc_tutorial:my_desc_dataset_1.1.0\",\n",
+    ")\n",
+    "\n",
+    "# This is the unique identifier assigned to the updated dataset from the registry\n",
+    "print(f\"Dataset {updated_dataset_id} created\")\n",
+    "\n",
+    "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
+    "print(f\"Dataset assigned to execution {updated_execution_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbdff8de-973e-4aa6-90ba-42f448d87222",
+   "metadata": {},
+   "source": [
+    "will create a new dataset, version `1.1.1`, but the new data has overwritten the data for version `1.1.0`."
    ]
   },
   {
@@ -385,6 +431,54 @@
     "    url=\"www.data.com\",\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e95c0aa9-3b05-4b80-a91c-e6f643365bcb",
+   "metadata": {},
+   "source": [
+    "### Specifying the relative path\n",
+    "\n",
+    "Datasets are registered within the registry under a path relative to the root directory (`root_dir`), which, by default, is a shared space at NERSC. \n",
+    "\n",
+    "By default, the `relative_path` is constructed from the `name`, `version` and `version_suffix` (if there is one), in the format `relative_path=<name>_<version>_<version_suffix>`. However, one can also manually select the `relative_path` during registration, for example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2eda857c-e9b5-40ab-999f-65b858831a08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add new entry with a manual relative path.\n",
+    "datareg.Registrar.dataset.register(\n",
+    "    \"nersc_tutorial:my_desc_dataset_with_relative_path\",\n",
+    "    \"1.0.0\",\n",
+    "    is_dummy=True, # For testing purposes, means we need no actual data to work (only a database entry is created)\n",
+    "    relative_path=\"nersc_tutorial/my_desc_dataset\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dbb1c0a-70b8-452b-8b13-a98901359afa",
+   "metadata": {},
+   "source": [
+    "will register a dataset under the `relative_path` of `nersc_tutorial/my_desc_dataset`.\n",
+    "\n",
+    "For those interested, the eventual full path for the dataset will be `<root_dir>/<schema>/<owner_type>/<owner>/<relative_path>`. This means that the combination of `relative_path`, `owner` and `owner_type` must be unique within the registry, and therefore cannot already be taken when you register a new dataset (an exception to this is if you allow your datasets to be overwritable). \n",
+    "\n",
+    "You can leave `name` as `None` when registering using a manual `relative_path`, which will construct the `name` automatically from the `relative_path`- However we always recommend being explicit and choosing a `name` also."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2222b9e-c986-4595-9404-2fd56eb40c5f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
+++ b/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
@@ -194,7 +194,9 @@
     "\n",
     "### The dataset name (mandatory)\n",
     "\n",
-    "The first of two mandatory arguments to the `register()` function is the dataset `name`, which in our example is `nersc_tutorial:my_desc_dataset` (note there is nothing special about the `:` here, the `name` can be any legal string). This should be any convenient, evocative name for the human. Note the combination of `name`, `version` and `version_suffix` must be unique in the database. The dataset `name` allows for an easy retrieval of the dataset for querying and updating.\n",
+    "The first of two mandatory arguments to the `register()` function is the dataset `name`, which in our example is `nersc_tutorial:my_desc_dataset` (note there is nothing special about the `:` here, the `name` can be any legal string). This should be any convenient, evocative name for the human, however note that the special characters `&*/\\?$` are not allowed to be part of the `name` string. The combination of `name`, `version` and `version_suffix` must be unique in the database.\n",
+    "\n",
+    "The dataset `name` allows for an easy retrieval of the dataset for querying and updating.\n",
     "\n",
     "### The version string (mandatory)\n",
     "\n",
@@ -237,13 +239,11 @@
     "\n",
     "If you have a dataset that has been previously registered within the data registry, and that dataset has updates, you have three options for how to handle the new entry:\n",
     "\n",
-    "1. You can enter it as a completely new standalone dataset with no links to the previous dataset\n",
-    "2. You can enter it as a new version of the previous dataset (recommended)\n",
-    "3. You can overwrite the existing dataset with the new data (only if the previous dataset was entered with `is_overwritable=True`)\n",
+    "1. You can enter it as a new version of the previous dataset (recommended in most situations)\n",
+    "2. You can overwrite the existing dataset with the new data (only if the previous dataset was entered with `is_overwritable=True`)\n",
+    "3. You can enter it as a completely new standalone dataset with no links to the previous dataset\n",
     "\n",
-    "For 1. simply follow the procedure above for registering a new dataset.\n",
-    "\n",
-    "For 2. we register a new dataset as before, making sure to keep the same dataset `name`, but updating the dataset `version`. One can update the `version` in two ways: manually entering a new version string, or having the `dataregistry` automatically \"bump\" the dataset version by selecing either \"major\", \"minor\" or \"patch\" for the version string. For example, lets register an updated version of our dataset, bumping the minor tag (i.e., bumping `1.0.0` -> `1.1.0`)."
+    "For 1. we register a new dataset as before, making sure to keep the same dataset `name`, but updating the dataset `version`. One can update the `version` in two ways: manually entering a new version string, or having the `dataregistry` automatically \"bump\" the dataset version by selecing either \"major\", \"minor\" or \"patch\" for the version string. For example, lets register an updated version of our dataset, bumping the minor tag (i.e., bumping `1.0.0` -> `1.1.0`)."
    ]
   },
   {
@@ -282,7 +282,7 @@
    "source": [
     "Note that both sets of data, from version `1.0.0` and `1.1.0` still exist, and they are linked through the dataset `name`.\n",
     "\n",
-    "For 3., to update a previous dataset and overwrite the existing data, we have the pass the `relative_path` of the existing dataset (see Section 6 for more details on the `relative_path`). For example"
+    "For 2., to update a previous dataset and overwrite the existing data, we have to pass the `relative_path` of the existing dataset (see Section 6 for more details on the `relative_path`). For example"
    ]
   },
   {
@@ -318,7 +318,9 @@
    "id": "dbdff8de-973e-4aa6-90ba-42f448d87222",
    "metadata": {},
    "source": [
-    "will create a new dataset, version `1.1.1`, but the new data has overwritten the data for version `1.1.0`."
+    "will create a new dataset, version `1.1.1`, but the new data has overwritten the data for version `1.1.0`.\n",
+    "\n",
+    "For 3. simply follow the procedure above for registering a new dataset."
    ]
   },
   {

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -19,6 +19,7 @@ from .registrar_util import (
 )
 from .dataset_util import set_dataset_status, get_dataset_status
 
+_ILLEGAL_NAME_CHAR = ["$","*","&","/","?","\\"]
 
 class DatasetTable(BaseTable):
     def __init__(self, db_connection, root_dir, owner, owner_type, execution_table):
@@ -119,6 +120,11 @@ class DatasetTable(BaseTable):
             The execution ID associated with the dataset
         """
 
+        # If `old_location` is None, we need a relative path
+        if old_location is None and location_type == "dataregistry":
+            if relative_path is None:
+                raise ValueError("`relative_path` is required when `old_location` is None")
+
         # If no name, we need a `relative_path`
         if name is None:
             if relative_path is None:
@@ -188,6 +194,11 @@ class DatasetTable(BaseTable):
         # If `name` is None, generate it from the `relative_path`
         if name is None:
             name = _name_from_relpath(relative_path)
+
+        # Make sure `name` is legal (i.e., no illegal characters)
+        for i_char in _ILLEGAL_NAME_CHAR:
+            if i_char in name:
+                raise ValueError(f"Cannot have character {i_char} in name string")
 
         # Look for previous entries. Fail if not overwritable
         previous = self._find_previous(relative_path, owner, owner_type)

--- a/src/dataregistry/registrar/registrar_util.py
+++ b/src/dataregistry/registrar/registrar_util.py
@@ -340,3 +340,32 @@ def _copy_data(dataset_organization, source, dest, do_checksum=True):
         )
 
         raise Exception(e)
+
+def _relpath_from_name(name, version, version_suffix):
+    """
+    Construct a relative path from the name and version of a dataset.
+
+    We use this when the `relative_path` is not explicitly defined. To be safe
+    from conflicts we also append the current timestamp to the relative_path.
+
+    Parameters
+    ----------
+    name : str
+        Dataset name
+    version : str
+        Dataset version
+    version_suffix : str
+        Dataset version suffix
+
+    Returns
+    -------
+    relative_path : str
+        Automatically generated `relative_path`
+    """
+
+    if version_suffix is not None:
+        relative_path = f"{name}_{version}_{version_suffix}"
+    else:
+        relative_path = f"{name}_{version}"
+    
+    return relative_path

--- a/src/dataregistry/registrar/registrar_util.py
+++ b/src/dataregistry/registrar/registrar_util.py
@@ -12,6 +12,7 @@ __all__ = [
     "_form_dataset_path",
     "get_directory_info",
     "_name_from_relpath",
+    "_relpath_from_name",
     "_copy_data",
 ]
 VERSION_SEPARATOR = "."

--- a/src/dataregistry/registrar/registrar_util.py
+++ b/src/dataregistry/registrar/registrar_util.py
@@ -346,8 +346,7 @@ def _relpath_from_name(name, version, version_suffix):
     """
     Construct a relative path from the name and version of a dataset.
 
-    We use this when the `relative_path` is not explicitly defined. To be safe
-    from conflicts we also append the current timestamp to the relative_path.
+    We use this when the `relative_path` is not explicitly defined.
 
     Parameters
     ----------

--- a/src/dataregistry/schema/schema.yaml
+++ b/src/dataregistry/schema/schema.yaml
@@ -177,12 +177,12 @@ dataset:
     description: "Unique identifier for this dataset"
   name:
     type: "String"
-    description: "Any convenient, evocative name for the human. Note the combination of name, version and version_suffix must be unique. If None name is generated from the relative path."
+    description: "Any convenient, evocative name for the human. Note the combination of name, version and version_suffix must be unique."
     nullable: False
     cli_optional: True
   relative_path:
     type: "String"
-    description: "Relative path storing the data, relative to `<root_dir>`"
+    description: "Relative path storing the data, relative to `<root_dir>`.  If None name is generated automatically from the provided name and version."
     nullable: False
   version_major:
     type: "Integer"

--- a/src/dataregistry/schema/schema.yaml
+++ b/src/dataregistry/schema/schema.yaml
@@ -179,11 +179,11 @@ dataset:
     type: "String"
     description: "Any convenient, evocative name for the human. Note the combination of name, version and version_suffix must be unique."
     nullable: False
-    cli_optional: True
   relative_path:
     type: "String"
     description: "Relative path storing the data, relative to `<root_dir>`.  If None name is generated automatically from the provided name and version."
     nullable: False
+    cli_optional: True
   version_major:
     type: "Integer"
     description: "Major version in semantic string (i.e., X.x.x)"

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -123,10 +123,10 @@ def get_parser():
     
     # Entries unique to registering the dataset when using the CLI
     arg_register_dataset.add_argument(
-        "relative_path",
+        "name",
         help=(
-            "Destination for the dataset within the data registry. Path is"
-            "relative to <registry root>/<owner_type>/<owner>."
+            "Any convenient, evocative name for the human."
+            "Note the combination of name, version and version_suffix must be unique."
         ),
         type=str,
     )

--- a/src/dataregistry_cli/register.py
+++ b/src/dataregistry_cli/register.py
@@ -38,9 +38,8 @@ def register_dataset(args):
 
     # Register new dataset.
     new_id = datareg.Registrar.dataset.register(
-        args.relative_path,
+        args.name,
         args.version,
-        name=args.name,
         version_suffix=args.version_suffix,
         creation_date=args.creation_date,
         access_API=args.access_API,
@@ -60,6 +59,7 @@ def register_dataset(args):
         location_type=args.location_type,
         url=args.url,
         contact_email=args.contact_email,
+        relative_path=args.relative_path,
     )
 
     print(f"Created dataset entry with id {new_id}")

--- a/tests/end_to_end_tests/database_test_utils.py
+++ b/tests/end_to_end_tests/database_test_utils.py
@@ -144,12 +144,11 @@ def _insert_execution_entry(
 
 def _insert_dataset_entry(
     datareg,
-    relpath,
+    name,
     version,
     owner_type=None,
     owner=None,
     description=None,
-    name=None,
     execution_id=None,
     version_suffix=None,
     old_location=None,
@@ -164,15 +163,15 @@ def _insert_dataset_entry(
     location_type="dummy",
     contact_email=None,
     url=None,
+    relative_path=None,
 ):
     """
     Wrapper to create dataset entry
 
     Parameters
     ----------
-    relpath : str
-        Relative path within the data registry to store the data
-        Relative to <ROOT>/<owner_type>/<owner>/...
+    name : str
+        A user selected name for the dataset
     version : str
         Semantic version string (i.e., M.N.P) or
         "major", "minor", "patch" to automatically bump the version previous
@@ -182,8 +181,6 @@ def _insert_dataset_entry(
         Dataset owner
     description : str
         Description of dataset
-    name : str
-        A manually selected name for the dataset
     execution_id : int
         Execution entry related to this dataset
     version_suffix : str
@@ -205,10 +202,13 @@ def _insert_dataset_entry(
         List of dataset ids that were the input to this execution
     location_type : str, optional
         "dataregistry", "external" or "dummy"
-    contact_email : str
+    contact_email : str, optional
         Contact email for external datasets
-    url : str
+    url : str, optional
         Url for external datasets
+    relative_path : str, optional
+        Relative path within the data registry to store the data
+        Relative to <ROOT>/<owner_type>/<owner>/...
 
     Returns
     -------
@@ -221,10 +221,9 @@ def _insert_dataset_entry(
 
     # Add new entry.
     dataset_id, execution_id = datareg.Registrar.dataset.register(
-        relpath,
+        name,
         version,
         version_suffix=version_suffix,
-        name=name,
         creation_date=None,
         description=description,
         old_location=old_location,
@@ -243,6 +242,7 @@ def _insert_dataset_entry(
         location_type=location_type,
         contact_email=contact_email,
         url=url,
+        relative_path=relative_path,
     )
 
     assert dataset_id is not None, "Trying to create a dataset that already exists"

--- a/tests/end_to_end_tests/test_cli.py
+++ b/tests/end_to_end_tests/test_cli.py
@@ -20,7 +20,7 @@ def test_simple_query(dummy_file):
     cli.main(shlex.split(cmd))
 
     # Update the registered dataset
-    cmd = "register dataset my_cli_dataset2 patch --location_type dummy --name my_cli_dataset"
+    cmd = "register dataset my_cli_dataset patch --location_type dummy"
     cmd += f" --schema {SCHEMA_VERSION} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
@@ -40,7 +40,7 @@ def test_dataset_entry_with_execution(dummy_file):
     tmp_src_dir, tmp_root_dir = dummy_file
 
     # Register a dataset with many options
-    cmd = "register dataset my_cli_dataset3 1.2.3 --location_type dummy"
+    cmd = "register dataset my_cli_dataset_with_ex 1.2.3 --location_type dummy"
     cmd += " --description 'This is my dataset description'"
     cmd += " --access_API 'Awesome API' --owner DESC --owner_type group"
     cmd += " --version_suffix test --creation_date '2020-01-01'"
@@ -51,14 +51,11 @@ def test_dataset_entry_with_execution(dummy_file):
 
     # Check
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
-    f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset3")
+    f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_with_ex")
     results = datareg.Query.find_datasets(
         [
             "dataset.name",
-            "dataset.version_string",
-            "dataset.relative_path",
             "execution.name",
-            "execution.execution_id",
             "dataset.is_overwritable",
         ],
         [f],
@@ -86,7 +83,7 @@ def test_production_entry(dummy_file):
         # Check
         f = datareg.Query.gen_filter("dataset.name", "==", "my_production_cli_dataset")
         results = datareg.Query.find_datasets(
-            ["dataset.name", "dataset.version_string", "dataset.relative_path"], [f]
+            ["dataset.name", "dataset.version_string"], [f]
         )
         assert len(results["dataset.name"]) == 1, "Bad result from query dcli3"
         assert results["dataset.version_string"][0] == "0.1.2"

--- a/tests/end_to_end_tests/test_database_functions.py
+++ b/tests/end_to_end_tests/test_database_functions.py
@@ -41,10 +41,11 @@ def test_get_dataset_absolute_path(dummy_file):
     # Make a basic entry
     d_id_1 = _insert_dataset_entry(
         datareg,
-        dset_relpath,
+        "dataset_test_get_dataset_absolute_path",
         "0.0.1",
         owner_type=dset_ownertype,
         owner=dset_owner,
+        relative_path=dset_relpath,
     )
 
     v = datareg.Query.get_dataset_absolute_path(d_id_1)
@@ -72,7 +73,12 @@ def test_find_entry(dummy_file):
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
     # Make a dataset
-    d_id = _insert_dataset_entry(datareg, "test_find_entry/dataset", "0.0.1")
+    d_id = _insert_dataset_entry(
+        datareg,
+        "dataset_test_find_entry",
+        "0.0.1",
+        relative_path="test_find_entry/dataset",
+    )
 
     # Find it
     r = datareg.Registrar.dataset.find_entry(d_id)

--- a/tests/end_to_end_tests/test_delete_dataset.py
+++ b/tests/end_to_end_tests/test_delete_dataset.py
@@ -56,7 +56,7 @@ def test_delete_dataset_entry(dummy_file, is_dummy, dataset_name):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{dataset_name}",
+        f"DESC:datasets:{dataset_name}",
         "0.0.1",
         location_type=location_type,
         old_location=data_path,

--- a/tests/end_to_end_tests/test_modify.py
+++ b/tests/end_to_end_tests/test_modify.py
@@ -24,7 +24,7 @@ def test_modify_dataset(dummy_file, dataset_name, column, new_value):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{dataset_name}",
+        f"DESC:datasets:{dataset_name}",
         "0.0.1",
         location_type="dummy",
     )
@@ -85,7 +85,7 @@ def test_modify_not_allowed(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/bad_modify",
+        f"DESC:datasets:bad_modify",
         "0.0.1",
         location_type="dummy",
     )

--- a/tests/end_to_end_tests/test_production_schema.py
+++ b/tests/end_to_end_tests/test_production_schema.py
@@ -27,14 +27,14 @@ def test_register_with_production_dependencies(dummy_file):
     # Make a dataset in each schema
     d_id_prod = _insert_dataset_entry(
         datareg_prod,
-        "DESC/datasets/production_dataset_for_deps",
+        "DESC:datasets:production_dataset_for_deps",
         "0.0.1",
         owner_type="production",
     )
 
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/nonproduction_dataset_for_deps",
+        "DESC:datasets:nonproduction_dataset_for_deps",
         "0.0.1",
     )
 
@@ -80,7 +80,7 @@ def test_production_schema_register(dummy_file):
 
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/production_dataset_1",
+        "DESC:datasets:production_dataset_1",
         "0.0.1",
         owner_type="production",
     )
@@ -116,7 +116,7 @@ def test_production_schema_bad_register(dummy_file):
     with pytest.raises(ValueError, match="can go in the production schema"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_1",
+            "DESC:datasets:bad_production_dataset_1",
             "0.0.1",
             owner_type="user",
         )
@@ -125,7 +125,7 @@ def test_production_schema_bad_register(dummy_file):
     with pytest.raises(ValueError, match="Cannot overwrite production entries"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_2",
+            "DESC:datasets:bad_production_dataset_2",
             "0.0.1",
             owner_type="production",
             is_overwritable=True,
@@ -137,7 +137,7 @@ def test_production_schema_bad_register(dummy_file):
     ):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_3",
+            "DESC:datasets:bad_production_dataset_3",
             "0.0.1",
             owner_type="production",
             version_suffix="prod",

--- a/tests/end_to_end_tests/test_register_dataset_dummy.py
+++ b/tests/end_to_end_tests/test_register_dataset_dummy.py
@@ -432,3 +432,33 @@ def test_manual_relative_path_and_auto_name(dummy_file, relative_path):
         assert getattr(r, "dataset.name") == "auto_name_dataset"
         assert getattr(r, "dataset.relative_path") == relative_path
         assert i < 1
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        ("slashes/are/bad"),
+        (r"slashes\are\bad"),
+        ("questions?"),
+        ("stars*"),
+        ("dollar$"),
+        ("amper&sand"),
+    ],
+)
+def test_illegal_dataset_name(dummy_file,name):
+    """
+    Registering datasets with illegal names should fail
+
+    Illegal names are those with characters "/\?*$&"
+    """
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+
+    # Add entry with bad name
+    with pytest.raises(ValueError, match="Cannot have character"):
+        d_id = _insert_dataset_entry(
+            datareg,
+            name,
+            "1.0.0",
+        )

--- a/tests/end_to_end_tests/test_register_dataset_dummy.py
+++ b/tests/end_to_end_tests/test_register_dataset_dummy.py
@@ -23,9 +23,10 @@ def test_register_dataset(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_dataset",
+        "my_first_dummy_dataset",
         "0.0.1",
         description="This is my first DESC dataset",
+        version_suffix="v1",
     )
 
     # Query
@@ -34,6 +35,7 @@ def test_register_dataset(dummy_file):
         [
             "dataset.name",
             "dataset.version_string",
+            "dataset.version_suffix",
             "dataset.owner",
             "dataset.owner_type",
             "dataset.description",
@@ -41,7 +43,6 @@ def test_register_dataset(dummy_file):
             "dataset.version_minor",
             "dataset.version_patch",
             "dataset.relative_path",
-            "dataset.version_suffix",
             "dataset.data_org",
         ],
         [f],
@@ -49,55 +50,60 @@ def test_register_dataset(dummy_file):
     )
 
     for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "my_first_dataset"
+        assert getattr(r, "dataset.name") == "my_first_dummy_dataset"
         assert getattr(r, "dataset.version_string") == "0.0.1"
+        assert getattr(r, "dataset.version_suffix") == "v1"
         assert getattr(r, "dataset.version_major") == 0
         assert getattr(r, "dataset.version_minor") == 0
         assert getattr(r, "dataset.version_patch") == 1
         assert getattr(r, "dataset.owner") == os.getenv("USER")
         assert getattr(r, "dataset.owner_type") == "user"
         assert getattr(r, "dataset.description") == "This is my first DESC dataset"
-        assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
-        assert getattr(r, "dataset.version_suffix") == None
+        assert getattr(r, "dataset.relative_path") == "my_first_dummy_dataset_0.0.1_v1"
+        assert getattr(r, "dataset.version_suffix") == "v1"
         assert getattr(r, "dataset.data_org") == "dummy"
         assert i < 1
 
 
-def test_manual_name_and_vsuffix(dummy_file):
-    """Test setting the name and version suffix manually"""
+def test_manual_relative_path(dummy_file):
+    """Test setting the relative path manually when registering a dataset"""
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
     # Add entry
+    my_rel_path = "ci_tests/dummy_dataset/my_second_dummy_dataset"
+    my_owner = "DESC"
+    my_owner_type = "group"
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_second_dataset",
+        "my_second_dummy_dataset",
         "0.0.1",
-        name="custom name",
-        version_suffix="custom_suffix",
+        relative_path=my_rel_path,
+        owner=my_owner,
+        owner_type=my_owner_type,
     )
 
     # Query
     f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
     results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
+        [
+            "dataset.name",
+            "dataset.relative_path",
+            "dataset.owner",
+            "dataset.owner_type",
+        ],
+        [f],
+        return_format="cursorresult",
     )
 
     for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "custom name"
-        assert getattr(r, "dataset.version_suffix") == "custom_suffix"
+        assert getattr(r, "dataset.name") == "my_second_dummy_dataset"
+        assert getattr(r, "dataset.relative_path") == my_rel_path
+        assert getattr(r, "dataset.owner") == my_owner
+        assert getattr(r, "dataset.owner_type") == my_owner_type
         assert i < 1
-
-    # Try to bump dataset with version suffix (should fail)
-    with pytest.raises(ValueError, match="Cannot bump"):
-        d_id = _insert_dataset_entry(
-            datareg,
-            "DESC/datasets/my_second_dataset_bumped",
-            "major",
-            name="custom name",
-        )
 
 
 @pytest.mark.parametrize(
@@ -112,11 +118,7 @@ def test_manual_name_and_vsuffix(dummy_file):
     ],
 )
 def test_dataset_bumping(dummy_file, v_type, ans, name):
-    """
-    Test bumping a dataset and make sure the new version is correct.
-
-    Tests bumping datasets with and without a version suffix.
-    """
+    """Test bumping a dataset and make sure the new version is correct"""
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
@@ -125,21 +127,44 @@ def test_dataset_bumping(dummy_file, v_type, ans, name):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/bumped_dataset_{v_type}_{name}_{ans.replace('.','_')}",
+        name,
         v_type,
-        name=name,
     )
 
     # Query
     f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
     results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
+        ["dataset.name", "dataset.version_string", "dataset.relative_path"],
+        [f],
+        return_format="cursorresult",
     )
 
     for i, r in enumerate(results):
         assert getattr(r, "dataset.name") == name
         assert getattr(r, "dataset.version_string") == ans
+        assert getattr(r, "dataset.relative_path") == f"{name}_{ans}"
         assert i < 1
+
+
+def test_dataset_bumping_with_suffix(dummy_file):
+    """Test bumping a dataset with version suffix, should fail"""
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+
+    # Add entry
+    d_id = _insert_dataset_entry(
+        datareg, "bump_dummy_with_suffix", "1.0.0", version_suffix="v1"
+    )
+
+    # Try to bump it
+    with pytest.raises(ValueError, match="Cannot bump"):
+        _ = _insert_dataset_entry(
+            datareg,
+            "bump_dummy_with_suffix",
+            "major",
+        )
 
 
 @pytest.mark.parametrize("owner_type", ["user", "group", "project"])
@@ -153,7 +178,7 @@ def test_dataset_owner_types(dummy_file, owner_type):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/owner_type_{owner_type}",
+        f"dataset_owner_type_{owner_type}",
         "0.0.1",
         owner_type=owner_type,
     )
@@ -187,7 +212,7 @@ def test_register_dataset_with_global_owner_set(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/global_user_dataset",
+        "global_owner_and_owner_type_dataset",
         "0.0.1",
         owner=None,
         owner_type=None,
@@ -222,13 +247,13 @@ def test_register_dataset_with_modified_default_execution(dummy_file):
 
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/execution_test_input",
+        "dataset_with_default_execution",
         "0.0.1",
     )
 
     d_id_2 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/execution_test",
+        "dataset_with_manual_execution",
         "0.0.1",
         execution_name="Overwrite execution auto name",
         execution_description="Overwrite execution auto description",
@@ -295,7 +320,7 @@ def test_dataset_query_return_format(dummy_file, return_format_str, expected_typ
     # Register a dataset
     d_id_1 = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/query_return_test_{return_format_str}",
+        f"dataset_query_return_test_{return_format_str}",
         "3.2.1",
     )
 
@@ -319,7 +344,7 @@ def test_query_all(dummy_file):
     # Register a dataset
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/test_return_all",
+        "test_return_all_dataset",
         "3.2.1",
     )
 

--- a/tests/end_to_end_tests/test_register_dataset_dummy.py
+++ b/tests/end_to_end_tests/test_register_dataset_dummy.py
@@ -351,3 +351,39 @@ def test_query_all(dummy_file):
     results = datareg.Query.find_datasets()
 
     assert results is not None
+
+def test_manual_relative_path_and_auto_name(dummy_file):
+    """
+    Test setting the relative path manually when registering a dataset.
+
+    In this case generate the dataset name from the relative path.
+    """
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+
+    # Add entry
+    my_rel_path = "ci_tests/dummy_dataset/auto_name_dataset"
+    d_id = _insert_dataset_entry(
+        datareg,
+        None,
+        "0.0.1",
+        relative_path=my_rel_path,
+    )
+
+    # Query
+    f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
+    results = datareg.Query.find_datasets(
+        [
+            "dataset.name",
+            "dataset.relative_path",
+        ],
+        [f],
+        return_format="cursorresult",
+    )
+
+    for i, r in enumerate(results):
+        assert getattr(r, "dataset.name") == "auto_name_dataset"
+        assert getattr(r, "dataset.relative_path") == my_rel_path
+        assert i < 1

--- a/tests/end_to_end_tests/test_register_dataset_external.py
+++ b/tests/end_to_end_tests/test_register_dataset_external.py
@@ -24,7 +24,7 @@ def test_bad_register_dataset_external(dummy_file):
     with pytest.raises(ValueError, match="require either a url or contact_email"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/my_first_external_dataset",
+            "DESC:datasets:my_first_external_dataset",
             "0.0.1",
             location_type="external",
         )
@@ -48,7 +48,7 @@ def test_register_dataset_external(dummy_file, contact_email, url, rel_path):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{rel_path}",
+        f"DESC:datasets:{rel_path}",
         "0.0.1",
         location_type="external",
         contact_email=contact_email,

--- a/tests/end_to_end_tests/test_register_dataset_real_data.py
+++ b/tests/end_to_end_tests/test_register_dataset_real_data.py
@@ -10,7 +10,6 @@ from dataregistry.registrar.registrar_util import _form_dataset_path
 
 from database_test_utils import *
 
-
 @pytest.mark.parametrize("data_org", ["file", "directory"])
 def test_copy_data(dummy_file, data_org):
     """Test copying real data into the registry (from an `old_location`)"""
@@ -28,7 +27,7 @@ def test_copy_data(dummy_file, data_org):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/copy_real_{data_org}",
+        f"dataset_copy_real_{data_org}",
         "0.0.1",
         old_location=data_path,
         location_type="dataregistry",
@@ -81,6 +80,7 @@ def test_on_location_data(dummy_file, data_org, data_path, v_str, overwritable):
         old_location=None,
         location_type="dataregistry",
         is_overwritable=overwritable,
+        relative_path=data_path,
     )
 
     f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)

--- a/tests/end_to_end_tests/test_register_pipeline.py
+++ b/tests/end_to_end_tests/test_register_pipeline.py
@@ -67,7 +67,7 @@ def test_pipeline_entry(dummy_file):
     # Datasets for stage 1
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage1",
+        "DESC:datasets:my_first_pipeline_stage1",
         "0.0.1",
         execution_id=ex_id_1,
     )
@@ -85,7 +85,7 @@ def test_pipeline_entry(dummy_file):
     # Datasets for stage 2
     d_id_2 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage2a",
+        "DESC:datasets:my_first_pipeline_stage2a",
         "0.0.1",
         execution_id=ex_id_2,
     )
@@ -93,7 +93,7 @@ def test_pipeline_entry(dummy_file):
 
     d_id_3 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage2b",
+        "DESC:datasets:my_first_pipeline_stage2b",
         "0.0.1",
         execution_id=ex_id_2,
     )

--- a/tests/unit_tests/test_registrar_util.py
+++ b/tests/unit_tests/test_registrar_util.py
@@ -4,6 +4,7 @@ import pytest
 from dataregistry.registrar.registrar_util import (
     _form_dataset_path,
     _relpath_from_name,
+    _name_from_relpath,
     _parse_version_string,
     _read_configuration_file,
     get_directory_info,
@@ -149,3 +150,17 @@ def test_relpath_from_name(name, version_string, version_suffix, ans):
 
     tmp = _relpath_from_name(name, version_string, version_suffix)
     assert tmp == ans
+
+@pytest.mark.parametrize(
+    "rel_path,ans",
+    [
+        ("/testing/test", "test"),
+        ("./testing/test", "test"),
+        ("/testing/test/", "test"),
+        ("test", "test"),
+    ],
+)
+def test_name_from_relpath(rel_path,ans):
+    """Make sure names are extracted from paths correctly"""
+
+    assert _name_from_relpath(rel_path) == ans

--- a/tests/unit_tests/test_registrar_util.py
+++ b/tests/unit_tests/test_registrar_util.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from dataregistry.registrar.registrar_util import (
     _form_dataset_path,
-    _name_from_relpath,
+    _relpath_from_name,
     _parse_version_string,
     _read_configuration_file,
     get_directory_info,
@@ -82,33 +82,6 @@ def test_directory_info():
     assert total_size > 0
 
 
-@pytest.mark.parametrize(
-    "owner_type,owner,rel_path,root_dir,ans",
-    [
-        ("production", "desc", "my/path", None, "production/production/my/path"),
-        (
-            "production",
-            "desc",
-            "my/path",
-            "my/root",
-            "my/root/production/production/my/path",
-        ),
-        ("group", "desc", "my/path", None, "group/desc/my/path"),
-        ("user", "desc", "my/path", "/root/", "/root/user/desc/my/path"),
-    ],
-)
-def test_form_dataset_path(owner_type, owner, rel_path, root_dir, ans):
-    """
-    Test dataset path construction
-
-    Datasets should come back with the format:
-        <root_dir>/<owner_type>/<owner>/<relative_path>
-    """
-
-    tmp = _form_dataset_path(owner_type, owner, rel_path, root_dir=root_dir)
-    assert tmp == ans
-
-
 def _make_dummy_config(tmpdir, nchars):
     """
     Create a dummy config file in temp directory
@@ -158,3 +131,21 @@ def test_read_file(tmpdir, nchars, max_config_length, ans):
     # Make sure we raise an exception when the file doesn't exist
     with pytest.raises(FileNotFoundError, match="not found"):
         _read_configuration_file("i_dont_exist.txt", 10)
+
+@pytest.mark.parametrize(
+    "name,version_string,version_suffix,ans",
+    [
+        ("mydataset", "1.1.1", None, "mydataset_1.1.1"),
+        ("mydataset", "1.1.1", "v1", "mydataset_1.1.1_v1"),
+    ],
+)
+def test_relpath_from_name(name, version_string, version_suffix, ans):
+    """
+    Test dataset path construction
+
+    Datasets should come back with the format:
+        <root_dir>/<owner_type>/<owner>/<relative_path>
+    """
+
+    tmp = _relpath_from_name(name, version_string, version_suffix)
+    assert tmp == ans


### PR DESCRIPTION
When registering a dataset, now `name` is required and `relative_path` is generated from the `name`, as opposed to the other way round.

### Changelog

- `name` and `version` are now the two mandatory columns when registering a dataset, as opposed to `name` and `relative_path`
- If `relative_path` is not passed (as it is now optional), it is generated automatically in the format `relative_path=<name>_<version_string>_<version_suffix>`
- You still have the option of choosing the `relative_path=` location when registering, it's now just optional. If you have a `relative_path` chosen, you can leave the `name` field as `None`, and the `name` will be generated from the relative path as before.
- Updated the documentation to reflect the changes.
- Updated CI tests to reflect the changes, and added some for new cases.

### Thoughts
- Do we want the name/version/version_suffix to be unique for a user, it may be frustrating to think of a increasingly complex name each time if the unique constraint is over the whole database. This is still true if the name was generated from the relative path from before, though less likely. 
- People could technically chose the same name (by mistake), and happen to chose a different version. Which will cause confusion down the line, which again maybe points to having names only unique to users.