### PR TITLE
Update CI Python version to 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,12 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
+        include:
+          - python-version: 3.9
+            if: github.event_name == 'pull_request'
+          - python-version: 3.11
+            if: github.event_name == 'pull_request'
 
     # Our CI steps for this job.
     steps:
@@ -105,7 +110,12 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
+        include:
+          - python-version: 3.9
+            if: github.event_name == 'pull_request'
+          - python-version: 3.11
+            if: github.event_name == 'pull_request'
 
     # Our CI steps for this job.
     steps:
@@ -162,7 +172,12 @@ jobs:
       fail-fast: false
 
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
+        include:
+          - python-version: 3.9
+            if: github.event_name == 'pull_request'
+          - python-version: 3.11
+            if: github.event_name == 'pull_request'
 
     # Our CI steps for this job.
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ authors = [
 license = { file = "LICENCE" }
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 keywords = ["desc", "python", "registry"]
 dependencies = [
@@ -23,7 +26,7 @@ dependencies = [
     'GitPython',
     'pandas'
 ]
-requires-python = ">=3.7" # For setuptools >= 61.0 support
+requires-python = ">=3.9,<3.12" # Supported versions (in CI)
 
 [tool.setuptools.dynamic]
 version = {attr = "dataregistry._version.__version__"}


### PR DESCRIPTION
Updates Python CI default version to 3.10 (for pushes)

Also added Python 3.9 and 3.11 checks during pull requests