### PR TITLE
Replace `relative_path` with `name` as the mandatory entry when registering datasets

### DIFF
--- a/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
+++ b/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
@@ -27,6 +27,7 @@
     "6) Special cases\n",
     "    * Registering external datasets\n",
     "    * Tagging datasets with keywords\n",
+    "    * Manually specifying the relative path\n",
     "\n",
     "### Before we begin\n",
     "\n",
@@ -114,7 +115,7 @@
     "# datareg = DataRegistry(schema=\"myschema\")\n",
     "\n",
     "# If you want to specify the root_dir that data is copied to (this should only be changed for testing purposes)\n",
-    "# datareg = DataRegistry(root_dir=\"/my/root/dir\")"
+    "#datareg = DataRegistry(root_dir=\"/my/root/dir\")"
    ]
   },
   {
@@ -147,8 +148,34 @@
     "tags": []
    },
    "source": [
-    "## 2) Registering new datasets with the `DataRegistry` class\n",
+    "## 2) Registering new datasets with the `DataRegistry` class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6797be3b-434f-4245-a276-a32d9294d1ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make some temporary text files that we can practice ingesting into the dataregistry with\n",
+    "import tempfile\n",
     "\n",
+    "temp_files = []\n",
+    "\n",
+    "# Create a temporary text file as some example data\n",
+    "for i in range(3):\n",
+    "    temp_file = tempfile.NamedTemporaryFile(delete=False)\n",
+    "    temp_file.write(b\"This is some temporary data, number \" + str(i).encode('utf-8'))\n",
+    "    temp_file.close()\n",
+    "    temp_files.append(temp_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c4865f-b8b8-4caf-8e0f-1166d6bcd3c1",
+   "metadata": {},
+   "source": [
     "Now that we have made our connection to the database, we can register some datasets using the `Registrar` extension of the `DataRegistry` class."
    ]
   },
@@ -161,19 +188,15 @@
    },
    "outputs": [],
    "source": [
-    "# Create an empty text file as some example data\n",
-    "with open(\"dummy_dataset.txt\", \"w\") as f:\n",
-    "    f.write(\"some data\")\n",
-    "\n",
     "# Add new entry.\n",
     "dataset_id, execution_id = datareg.Registrar.dataset.register(\n",
-    "    \"nersc_tutorial/my_desc_dataset\",\n",
+    "    \"nersc_tutorial:my_first_desc_dataset\",\n",
     "    \"1.0.0\",\n",
     "    description=\"An output from some DESC code\",\n",
     "    owner=\"DESC\",\n",
     "    owner_type=\"group\",\n",
     "    is_overwritable=True,\n",
-    "    old_location=\"dummy_dataset.txt\"\n",
+    "    old_location=temp_files[0].name\n",
     ")\n",
     "\n",
     "# This is the unique identifier assigned to the dataset from the registry\n",
@@ -192,13 +215,19 @@
    "source": [
     "This will register a new dataset. A few notes:\n",
     "\n",
+    "### The dataset name (mandatory)\n",
+    "\n",
+    "The first of two mandatory arguments to the `register()` function is the dataset `name`, which in our example is `nersc_tutorial:my_first_desc_dataset` (note there is nothing special about the \":\" here, the name can be any legal string). This should be any convenient, evocative name for the human, however note that the special characters `&*/\\?$` and spaces are not allowed to be part of the `name` string. The combination of `name`, `version` and `version_suffix` for any dataset must be unique in the database.\n",
+    "\n",
+    "The dataset `name` allows for an easy retrieval of the dataset for querying and updating.\n",
+    "\n",
     "### The relative path\n",
     "\n",
     "Datasets are registered within the registry under a path relative to the root directory (`root_dir`), which, by default, is a shared space at NERSC. For those interested, the eventual full path for the dataset will be `<root_dir>/<schema>/<owner_type>/<owner>/<relative_path>`. This means that the combination of `relative_path`, `owner` and `owner_type` must be unique within the registry, and therefore cannot already be taken when you register a new dataset (an exception to this is if you allow your datasets to be overwritable, see below). \n",
     "\n",
     "The relative path is one of the two required parameters you must specify when registering a dataset (in the example here our relative path is `nersc_tutorial/my_desc_dataset`).\n",
     "\n",
-    "### The version string\n",
+    "### The version string (mandatory)\n",
     "\n",
     "The second required parameter is the version string, in the semantic format, i.e., MAJOR.MINOR.PATCH. There exists also an optional ``version_suffix`` parameter, which may be used to further identify the dataset, e.g. with a value like \"rc1\" to make it clear it's only a release candidate, possibly not in its final form.\n",
     "\n",
@@ -239,34 +268,29 @@
     "\n",
     "If you have a dataset that has been previously registered within the data registry, and that dataset has updates, you have three options for how to handle the new entry:\n",
     "\n",
+    "- You can enter it as a newer version of the previous dataset (recommended in most situations)\n",
+    "- You can overwrite the existing dataset with the new data (only if the previous dataset was entered with is_overwritable=True)\n",
     "- You can enter it as a completely new standalone dataset with no links to the previous dataset\n",
-    "- You can overwrite the existing dataset with the new data (only if the previous dataset was entered with `is_overwritable=True`)\n",
-    "- You can enter it as a new version of the previous dataset (recommended)\n",
     "\n",
-    "Unless you are overwriting a previous dataset (when `is_overwritable=True`), you cannot enter a new dataset (even an updated version) using the same relative path. However, datasets can share the same `name` field, which acts as a reference for the dataset, and which is what we'll use to keep our updated dataset connected to our previous one.\n",
-    "\n",
-    "Note that for our test dataset entry above we did not specify a `name` during registration. The default `name` for a dataset is the file or directory name, extracted from the relative path. In our example above this was `my_desc_dataset`. If you are unsure of what name you specified for your previous dataset that you want to overwrite, you will need to query the database first to find out (see next tutorial for queries).\n",
-    "\n",
-    "The combination of `name`, `version` and `version_suffix` for any dataset must be unique. As we are updating a dataset with the same name, we have to make sure to update the version to a new value. One handy feature is automatic version \"bumping\" for datasets, i.e., rather than specifying a new version string manually, one can select \"major\", \"minor\" or \"patch\" for the version string to automatically bump that property of the version string up. In our case, selecting \"minor\" will automatically generate the version \"1.1.0\"."
+    "For 1. we register a new dataset as before, making sure to keep the same dataset `name`, but updating the dataset version. One can update the version in two ways: manually entering a new version string, or having the dataregistry automatically \"bump\" the dataset version by selecing either \"major\", \"minor\" or \"patch\" for the version string. For example, let's register an updated version of our dataset, bumping the minor tag (i.e., bumping 1.0.0 -> 1.1.0).\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88a01c97-a9f5-49b5-b8de-83712ac5f7f0",
-   "metadata": {
-    "tags": []
-   },
+   "id": "2a65d3c0-41c1-4720-85be-10d68cef84f9",
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Add new entry for an updated dataset with an updated version.\n",
     "updated_dataset_id, updated_execution_id = datareg.Registrar.dataset.register(\n",
-    "    \"nersc_tutorial/my_updated_desc_dataset\",\n",
+    "    \"nersc_tutorial:my_first_desc_dataset\",\n",
     "    \"minor\", # Automatically bumps to \"1.1.0\"\n",
     "    description=\"An output from some DESC code (updated)\",\n",
+    "    owner=\"DESC\",\n",
+    "    owner_type=\"group\",\n",
     "    is_overwritable=True,\n",
-    "    old_location=\"dummy_dataset.txt\",\n",
-    "    name=\"my_desc_dataset\" # Using this name links it to the previous dataset.\n",
+    "    old_location=temp_files[1].name,\n",
     ")\n",
     "\n",
     "# This is the unique identifier assigned to the updated dataset from the registry\n",
@@ -274,6 +298,52 @@
     "\n",
     "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
     "print(f\"Dataset assigned to execution {updated_execution_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43792dd5-a01b-4621-8808-c072c856f359",
+   "metadata": {},
+   "source": [
+    "Note that both sets of data, i.e., versions `1.0.0` and `1.1.0`, still exist, and they share the same dataset name.\n",
+    "\n",
+    "For 2., to update a previous dataset and overwrite the existing data in the `root_dir`, we have to pass the `relative_path` of the existing dataset (see Section 6 for more details on the `relative_path`). For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62733b65-e915-43d2-b944-cac60b9e9ea0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add new entry, overwriting the data in the `root_dir`.\n",
+    "updated_dataset_id, updated_execution_id = datareg.Registrar.dataset.register(\n",
+    "    \"nersc_tutorial:my_first_desc_dataset\",\n",
+    "    \"patch\", # Automatically bumps to \"1.1.1\"\n",
+    "    description=\"An output from some DESC code (further updated)\",\n",
+    "    owner=\"DESC\",\n",
+    "    owner_type=\"group\",\n",
+    "    is_overwritable=True,\n",
+    "    old_location=temp_files[2].name,\n",
+    "    relative_path=\"nersc_tutorial:my_first_desc_dataset_1.1.0\", # We overwrite the old data at this path\n",
+    ")\n",
+    "\n",
+    "# This is the unique identifier assigned to the updated dataset from the registry\n",
+    "print(f\"Dataset {updated_dataset_id} created\")\n",
+    "\n",
+    "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
+    "print(f\"Dataset assigned to execution {updated_execution_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12edcd2c-af04-4d5e-9891-080feada1040",
+   "metadata": {},
+   "source": [
+    "will create a new dataset, version 1.1.1, but the new data has overwritten the data for version 1.1.0.\n",
+    "\n",
+    "For 3. simply follow the procedure above for registering a new dataset."
    ]
   },
   {
@@ -377,14 +447,20 @@
    "outputs": [],
    "source": [
     "# Add new external dataset entry.\n",
-    "datareg.Registrar.dataset.register(\n",
-    "    \"nersc_tutorial/external_dataset\",\n",
+    "dataset_id, execution_id = datareg.Registrar.dataset.register(\n",
+    "    \"nersc_tutorial:external_dataset\",\n",
     "    \"0.0.1\",\n",
     "    description=\"Images from some external observatory\",\n",
     "    is_overwritable=True,\n",
     "    location_type=\"external\",\n",
     "    url=\"www.data.com\",\n",
-    ")"
+    ")\n",
+    "\n",
+    "# This is the unique identifier assigned to the updated dataset from the registry\n",
+    "print(f\"Dataset {dataset_id} created\")\n",
+    "\n",
+    "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
+    "print(f\"Dataset assigned to execution {execution_id}\")"
    ]
   },
   {
@@ -433,13 +509,20 @@
    "outputs": [],
    "source": [
     "# Add new dataset entry with keywords.\n",
-    "datareg.Registrar.dataset.register(\n",
+    "dataset_id, execution_id = datareg.Registrar.dataset.register(\n",
     "    \"nersc_tutorial:keywords_dataset\",\n",
     "    \"0.0.1\",\n",
     "    description=\"A dataset with some keywords tagged\",\n",
     "    is_overwritable=True,\n",
-    "    keywords=[\"simulation\"]\n",
-    ")"
+    "    keywords=[\"simulation\"],\n",
+    "    old_location=temp_files[0].name\n",
+    ")\n",
+    "\n",
+    "# This is the unique identifier assigned to the updated dataset from the registry\n",
+    "print(f\"Dataset {dataset_id} created\")\n",
+    "\n",
+    "# This is the id of the execution the updated dataset belongs to (see next tutorial)\n",
+    "print(f\"Dataset assigned to execution {execution_id}\")"
    ]
   },
   {
@@ -476,9 +559,47 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b4af4a61-3918-4334-92d8-1111cb9d5aac",
+   "metadata": {},
+   "source": [
+    "### Specifying the relative path\n",
+    "\n",
+    "Datasets are registered within the registry under a path relative to the root directory (`root_dir`), which, by default, is a shared space at NERSC.\n",
+    "\n",
+    "By default, the relative_path is constructed from the name, version and version_suffix (if there is one), in the format `relative_path=<name>/<version>_<version_suffix>`. However, one can also manually select the relative_path during registration, for example"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37cc9c11-2296-444d-a1ab-bde7b17c5d6a",
+   "id": "5bc0d5b6-f50a-4646-bc1b-7d9e829e91bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add new entry with a manual relative path.\n",
+    "datareg.Registrar.dataset.register(\n",
+    "    \"nersc_tutorial:my_desc_dataset_with_relative_path\",\n",
+    "    \"1.0.0\",\n",
+    "    relative_path=\"nersc_tutorial/my_desc_dataset\",\n",
+    "    old_location=temp_files[0].name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcacf4b1-dcb3-4632-af6d-a5aa6389100f",
+   "metadata": {},
+   "source": [
+    "will register a dataset under the `relative_path` of `nersc_tutorial/my_desc_dataset`.\n",
+    "\n",
+    "For those interested, the eventual full path for the dataset will be `<root_dir>/<schema>/<owner_type>/<owner>/<relative_path>`. This means that the combination of `relative_path`, `owner` and `owner_type` must be unique within the registry, and therefore cannot already be taken when you register a new dataset (an exception to this is if you allow your datasets to be overwritable)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be07a214-ca40-4e3f-a07f-a4db7e4038fd",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -500,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -197,17 +197,6 @@ class DatasetTable(BaseTable):
 
         dataset_table = self._get_table_metadata("dataset")
 
-        # Look for previous entries at the same location if dataset
-        # is in our managed area.   Fail if not overwritable
-        if location_type in ["dataregistry", "dummy"]:
-            previous = self._find_previous(relative_path, owner, owner_type)
-
-            if previous is None:
-                print(f"Dataset {relative_path} exists, and is not overwritable")
-                return None, None
-        else:
-            previous = []
-
         # Deal with version string (non-special case)
         if version not in ["major", "minor", "patch"]:
             v_fields = _parse_version_string(version)
@@ -223,6 +212,17 @@ class DatasetTable(BaseTable):
         # If `relative_path` not passed, automatically generate it
         if relative_path is None:
             relative_path = _relpath_from_name(name, version_string, version_suffix)
+
+        # Look for previous entries at the same location if dataset
+        # is in our managed area.   Fail if not overwritable
+        if location_type in ["dataregistry", "dummy"]:
+            previous = self._find_previous(relative_path, owner, owner_type)
+
+            if previous is None:
+                print(f"Dataset {relative_path} exists, and is not overwritable")
+                return None, None
+        else:
+            previous = []
 
         # If no execution_id is supplied, create a minimal entry
         if execution_id is None:

--- a/src/dataregistry/registrar/registrar_util.py
+++ b/src/dataregistry/registrar/registrar_util.py
@@ -261,7 +261,7 @@ def _read_configuration_file(configuration_file, max_config_length):
     return contents
 
 
-def _copy_data(dataset_organization, source, dest, do_checksum=True):
+def _copy_data(dataset_organization, source, dest, do_checksum=False):
     """
     Copy data from one location to another (for ingesting directories and files
     into the `root_dir` shared space.
@@ -331,13 +331,16 @@ def _copy_data(dataset_organization, source, dest, do_checksum=True):
     except Exception as e:
         if os.path.exists(temp_dest):
             if os.path.exists(dest):
-                rmtree(dest)
+                if dataset_organization == "file":
+                    os.remove(dest)
+                else:
+                    rmtree(dest)
             os.rename(temp_dest, dest)
 
         print(
             "Something went wrong during data copying, aborting."
             "Note an entry in the registry database will still have"
-            "been created"
+            f"been created ({e})"
         )
 
         raise Exception(e)

--- a/src/dataregistry/registrar/registrar_util.py
+++ b/src/dataregistry/registrar/registrar_util.py
@@ -13,6 +13,7 @@ __all__ = [
     "get_directory_info",
     "_name_from_relpath",
     "_copy_data",
+    "_relpath_from_name",
 ]
 VERSION_SEPARATOR = "."
 _nonneg_int_re = "0|[1-9][0-9]*"
@@ -340,3 +341,29 @@ def _copy_data(dataset_organization, source, dest, do_checksum=True):
         )
 
         raise Exception(e)
+
+def _relpath_from_name(name, version, version_suffix):
+    """
+    Construct a relative path from the name and version of a dataset.
+    We use this when the `relative_path` is not explicitly defined.
+
+    Parameters
+    ----------
+    name : str
+        Dataset name
+    version : str
+        Dataset version
+    version_suffix : str
+        Dataset version suffix
+    Returns
+    -------
+    relative_path : str
+        Automatically generated `relative_path`
+    """
+
+    if version_suffix is not None:
+        relative_path = f"{name}_{version}_{version_suffix}"
+    else:
+        relative_path = f"{name}_{version}"
+
+    return relative_path

--- a/src/dataregistry/schema/schema.yaml
+++ b/src/dataregistry/schema/schema.yaml
@@ -339,13 +339,13 @@ tables:
         description: "Unique identifier for this dataset"
       name:
         type: "String"
-        description: "Any convenient, evocative name for the human. Note the combination of name, version and version_suffix must be unique. If None name is generated from the relative path."
+        description: "Any convenient, evocative name for the human. Note the combination of name, version and version_suffix must be unique."
         nullable: False
-        cli_optional: True
       relative_path:
         type: "String"
-        description: "Relative path storing the data, relative to `<root_dir>`"
+        description: "Relative path storing the data, relative to `<root_dir>`. If None, generated from the `name`, `version_string` and `version_suffix`"
         nullable: False
+        cli_optional: True
       version_major:
         type: "Integer"
         description: "Major version in semantic string (i.e., X.x.x)"

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -141,10 +141,10 @@ def get_parser():
 
     # Entries unique to registering the dataset when using the CLI
     arg_register_dataset.add_argument(
-        "relative_path",
+        "name",
         help=(
-            "Destination for the dataset within the data registry. Path is"
-            "relative to <registry root>/<owner_type>/<owner>."
+            "Any convenient, evocative name for the human. Note the "
+            "combination of name, version and version_suffix must be unique."
         ),
         type=str,
     )

--- a/src/dataregistry_cli/register.py
+++ b/src/dataregistry_cli/register.py
@@ -38,9 +38,8 @@ def register_dataset(args):
 
     # Register new dataset.
     new_id = datareg.Registrar.dataset.register(
-        args.relative_path,
+        args.name,
         args.version,
-        name=args.name,
         version_suffix=args.version_suffix,
         creation_date=args.creation_date,
         access_api=args.access_api,
@@ -61,6 +60,7 @@ def register_dataset(args):
         url=args.url,
         contact_email=args.contact_email,
         keywords=args.keywords,
+        relative_path=args.relative_path,
     )
 
     print(f"Created dataset entry with id {new_id}")

--- a/tests/end_to_end_tests/database_test_utils.py
+++ b/tests/end_to_end_tests/database_test_utils.py
@@ -75,8 +75,7 @@ def dummy_file(tmp_path):
     return tmp_src_dir, tmp_root_dir
 
 
-def _insert_alias_entry(reg, name, dataset_id, ref_alias_id=None,
-                        supersede=False):
+def _insert_alias_entry(reg, name, dataset_id, ref_alias_id=None, supersede=False):
     """
     Wrapper to create dataset alias entry
 
@@ -100,9 +99,9 @@ def _insert_alias_entry(reg, name, dataset_id, ref_alias_id=None,
         The alias ID for this new entry
     """
 
-    new_id = reg.dataset_alias.register(name, dataset_id,
-                                        ref_alias_id=ref_alias_id,
-                                        supersede=supersede)
+    new_id = reg.dataset_alias.register(
+        name, dataset_id, ref_alias_id=ref_alias_id, supersede=supersede
+    )
     if not new_id:
         print("Dataset alias entry creation failed")
         if not supersede:
@@ -158,12 +157,11 @@ def _insert_execution_entry(
 
 def _insert_dataset_entry(
     datareg,
-    relpath,
+    name,
     version,
     owner_type=None,
     owner=None,
     description=None,
-    name=None,
     execution_id=None,
     version_suffix=None,
     old_location=None,
@@ -179,15 +177,15 @@ def _insert_dataset_entry(
     contact_email=None,
     url=None,
     keywords=[],
+    relative_path=None,
 ):
     """
     Wrapper to create dataset entry
 
     Parameters
     ----------
-    relpath : str
-        Relative path within the data registry to store the data
-        Relative to <ROOT>/<owner_type>/<owner>/...
+    name : str
+        A manually selected name for the dataset
     version : str
         Semantic version string (i.e., M.N.P) or
         "major", "minor", "patch" to automatically bump the version previous
@@ -226,6 +224,9 @@ def _insert_dataset_entry(
         Url for external datasets
     keywords : list[str]
         List of keywords to tag
+    relative_path : str
+        Relative path within the data registry to store the data
+        Relative to <ROOT>/<owner_type>/<owner>/...
 
     Returns
     -------
@@ -238,10 +239,9 @@ def _insert_dataset_entry(
 
     # Add new entry.
     dataset_id, execution_id = datareg.Registrar.dataset.register(
-        relpath,
+        name,
         version,
         version_suffix=version_suffix,
-        name=name,
         creation_date=None,
         description=description,
         old_location=old_location,
@@ -261,6 +261,7 @@ def _insert_dataset_entry(
         contact_email=contact_email,
         url=url,
         keywords=keywords,
+        relative_path=relative_path,
     )
 
     assert dataset_id is not None, "Trying to create a dataset that already exists"

--- a/tests/end_to_end_tests/database_test_utils.py
+++ b/tests/end_to_end_tests/database_test_utils.py
@@ -89,7 +89,7 @@ def _insert_alias_entry(reg, name, dataset_id, ref_alias_id=None, supersede=Fals
     ref_alias_id : int
         Optional.  If dataset_id is None, the new alias will point to
         the one identified by alias_id
-    supersed : boolean
+    supersede : boolean
         If True, make the entry even if the alias was already used. In this
         case mark old entries as superseded.
 

--- a/tests/end_to_end_tests/test_cli.py
+++ b/tests/end_to_end_tests/test_cli.py
@@ -8,6 +8,7 @@ from dataregistry.db_basic import SCHEMA_VERSION
 from database_test_utils import dummy_file
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
 
+
 def test_simple_query(dummy_file):
     """Make a simple entry, and make sure the query returns the correct result"""
 
@@ -20,7 +21,7 @@ def test_simple_query(dummy_file):
     cli.main(shlex.split(cmd))
 
     # Update the registered dataset
-    cmd = "register dataset my_cli_dataset2 patch --location_type dummy --name my_cli_dataset"
+    cmd = "register dataset my_cli_dataset patch --location_type dummy"
     cmd += f" --schema {SCHEMA_VERSION} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
@@ -28,7 +29,7 @@ def test_simple_query(dummy_file):
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset")
     results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_string", "dataset.relative_path"], [f]
+        ["dataset.name", "dataset.version_string"], [f]
     )
     assert len(results["dataset.name"]) == 2, "Bad result from query dcli1"
 
@@ -56,7 +57,6 @@ def test_dataset_entry_with_execution(dummy_file):
         [
             "dataset.name",
             "dataset.version_string",
-            "dataset.relative_path",
             "execution.name",
             "execution.execution_id",
             "dataset.is_overwritable",
@@ -86,7 +86,7 @@ def test_production_entry(dummy_file):
         # Check
         f = datareg.Query.gen_filter("dataset.name", "==", "my_production_cli_dataset")
         results = datareg.Query.find_datasets(
-            ["dataset.name", "dataset.version_string", "dataset.relative_path"], [f]
+            ["dataset.name", "dataset.version_string"], [f]
         )
         assert len(results["dataset.name"]) == 1, "Bad result from query dcli3"
         assert results["dataset.version_string"][0] == "0.1.2"
@@ -132,6 +132,7 @@ def test_delete_dataset(dummy_file):
         assert get_dataset_status(getattr(r, "dataset.status"), "deleted")
         assert getattr(r, "dataset.delete_date") is not None
         assert getattr(r, "dataset.delete_uid") is not None
+
 
 def test_dataset_entry_with_keywords(dummy_file):
     """Make a dataset with some keywords tagged"""

--- a/tests/end_to_end_tests/test_database_functions.py
+++ b/tests/end_to_end_tests/test_database_functions.py
@@ -17,17 +17,19 @@ def test_get_dataset_absolute_path(dummy_file):
     tmp_src_dir, tmp_root_dir = dummy_file
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
-    dset_relpath = "DESC/datasets/get_dataset_absolute_path_test"
+    dset_name = "DESC:datasets:get_dataset_absolute_path_test"
     dset_ownertype = "group"
     dset_owner = "group1"
+    dset_relpath = "my/path"
 
     # Make a basic entry
     d_id_1 = _insert_dataset_entry(
         datareg,
-        dset_relpath,
+        dset_name,
         "0.0.1",
         owner_type=dset_ownertype,
         owner=dset_owner,
+        relative_path=dset_relpath
     )
 
     v = datareg.Query.get_dataset_absolute_path(d_id_1)
@@ -55,13 +57,13 @@ def test_find_entry(dummy_file):
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
     # Make a dataset
-    d_id = _insert_dataset_entry(datareg, "test_find_entry/dataset", "0.0.1")
+    d_id = _insert_dataset_entry(datareg, "test_find_entry:dataset", "0.0.1")
 
     # Find it
     r = datareg.Registrar.dataset.find_entry(d_id)
     assert r is not None
     assert r.dataset_id == d_id
-    assert r.relative_path == "test_find_entry/dataset"
+    assert r.name == "test_find_entry:dataset"
     assert r.version_string == "0.0.1"
 
     # Make an execution
@@ -74,8 +76,7 @@ def test_find_entry(dummy_file):
     assert r.name == "test_find_entry_execution"
 
     # Make a dataset alias
-    da_id = _insert_alias_entry(datareg.Registrar,
-                                "test_find_entry_alias", d_id)
+    da_id = _insert_alias_entry(datareg.Registrar, "test_find_entry_alias", d_id)
 
     # Find it
     r = datareg.Registrar.dataset_alias.find_entry(da_id)
@@ -96,6 +97,7 @@ def test_get_modifiable_columns(dummy_file):
 
     mod_list = datareg.Registrar.execution.get_modifiable_columns()
     assert "description" in mod_list
+
 
 def test_get_keywords(dummy_file):
     """Test the `get_keywords()` function"""

--- a/tests/end_to_end_tests/test_delete_dataset.py
+++ b/tests/end_to_end_tests/test_delete_dataset.py
@@ -56,7 +56,7 @@ def test_delete_dataset_entry(dummy_file, is_dummy, dataset_name):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{dataset_name}",
+        f"DESC:datasets:{dataset_name}",
         "0.0.1",
         location_type=location_type,
         old_location=data_path,

--- a/tests/end_to_end_tests/test_keywords.py
+++ b/tests/end_to_end_tests/test_keywords.py
@@ -29,19 +29,20 @@ def test_register_dataset_with_bad_keywords(dummy_file):
     with pytest.raises(ValueError, match="not a valid keyword string"):
         _ = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/my_first_dataset_with_bad_keywords",
+            "DESC:datasets:my_first_dataset_with_bad_keywords",
             "0.0.1",
-            keywords=[10,20]
+            keywords=[10, 20],
         )
 
     # Test case where keywords are not previously registered in keyword table
     with pytest.raises(ValueError, match="Not all keywords"):
         _ = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/my_second_dataset_with_bad_keywords",
+            "DESC:datasets:my_second_dataset_with_bad_keywords",
             "0.0.1",
-            keywords=["bad_keyword"]
+            keywords=["bad_keyword"],
         )
+
 
 def test_register_dataset_with_keywords(dummy_file):
     """
@@ -57,16 +58,16 @@ def test_register_dataset_with_keywords(dummy_file):
     # Register two datasets with keywords
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_dataset_with_keywords",
+        "DESC:datasets:my_first_dataset_with_keywords",
         "0.0.1",
-        keywords=["simulation", "observation"]
+        keywords=["simulation", "observation"],
     )
 
     d_id2 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_second_dataset_with_keywords",
+        "DESC:datasets:my_second_dataset_with_keywords",
         "0.0.1",
-        keywords=["simulation"]
+        keywords=["simulation"],
     )
 
     # Query on the "simulation" keyword
@@ -82,6 +83,7 @@ def test_register_dataset_with_keywords(dummy_file):
         assert tmp_id in results["dataset.dataset_id"]
     for tmp_k in results["keyword.keyword"]:
         assert tmp_k == "simulation"
+
 
 def test_modify_dataset_with_keywords(dummy_file):
     """
@@ -99,9 +101,9 @@ def test_modify_dataset_with_keywords(dummy_file):
     # Register a dataset with keywords
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_modify_dataset_with_keywords",
+        "DESC:datasets:my_first_modify_dataset_with_keywords",
         "0.0.1",
-        keywords=["simulation"]
+        keywords=["simulation"],
     )
 
     # Query for the dataset

--- a/tests/end_to_end_tests/test_modify.py
+++ b/tests/end_to_end_tests/test_modify.py
@@ -24,7 +24,7 @@ def test_modify_dataset(dummy_file, dataset_name, column, new_value):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{dataset_name}",
+        f"DESC:datasets:{dataset_name}",
         "0.0.1",
         location_type="dummy",
     )
@@ -85,7 +85,7 @@ def test_modify_not_allowed(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/bad_modify",
+        f"DESC:datasets:bad_modify",
         "0.0.1",
         location_type="dummy",
     )

--- a/tests/end_to_end_tests/test_production_schema.py
+++ b/tests/end_to_end_tests/test_production_schema.py
@@ -27,14 +27,14 @@ def test_register_with_production_dependencies(dummy_file):
     # Make a dataset in each schema
     d_id_prod = _insert_dataset_entry(
         datareg_prod,
-        "DESC/datasets/production_dataset_for_deps",
+        "DESC:datasets:production_dataset_for_deps",
         "0.0.1",
         owner_type="production",
     )
 
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/nonproduction_dataset_for_deps",
+        "DESC:datasets:nonproduction_dataset_for_deps",
         "0.0.1",
     )
 
@@ -80,7 +80,7 @@ def test_production_schema_register(dummy_file):
 
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/production_dataset_1",
+        "DESC:datasets:production_dataset_1",
         "0.0.1",
         owner_type="production",
     )
@@ -116,7 +116,7 @@ def test_production_schema_bad_register(dummy_file):
     with pytest.raises(ValueError, match="can go in the production schema"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_1",
+            "DESC:datasets:bad_production_dataset_1",
             "0.0.1",
             owner_type="user",
         )
@@ -125,7 +125,7 @@ def test_production_schema_bad_register(dummy_file):
     with pytest.raises(ValueError, match="Cannot overwrite production entries"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_2",
+            "DESC:datasets:bad_production_dataset_2",
             "0.0.1",
             owner_type="production",
             is_overwritable=True,
@@ -137,7 +137,7 @@ def test_production_schema_bad_register(dummy_file):
     ):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/bad_production_dataset_3",
+            "DESC:datasets:bad_production_dataset_3",
             "0.0.1",
             owner_type="production",
             version_suffix="prod",

--- a/tests/end_to_end_tests/test_register_dataset_alias.py
+++ b/tests/end_to_end_tests/test_register_dataset_alias.py
@@ -48,19 +48,20 @@ def test_register_dataset_alias(dummy_file):
     assert a2_id is None
 
     # Try again with supersede
-    a2_id = _insert_alias_entry(datareg.Registrar, "nice_dataset_name", d2_id,
-                                supersede=True)
+    a2_id = _insert_alias_entry(
+        datareg.Registrar, "nice_dataset_name", d2_id, supersede=True
+    )
     assert a2_id is not None
 
     # Check that old entry with this alias has been marked as superseded
     f = datareg.Query.gen_filter("dataset_alias.dataset_alias_id", "==", a_id)
-    results = datareg.Query.find_aliases(property_names=["dataset_alias.supersede_date"],
-                                         filters=[f])
+    results = datareg.Query.find_aliases(
+        property_names=["dataset_alias.supersede_date"], filters=[f]
+    )
     assert results["dataset_alias.supersede_date"][0] is not None
 
     # Add an alias to the alias
-    aa_id = _insert_alias_entry(datareg.Registrar, "alias_to_alias", None,
-                                a2_id)
+    aa_id = _insert_alias_entry(datareg.Registrar, "alias_to_alias", None, a2_id)
     id, ref_type = datareg.Query.resolve_alias("alias_to_alias")
     assert id == a2_id
     assert ref_type == "alias"

--- a/tests/end_to_end_tests/test_register_dataset_dummy.py
+++ b/tests/end_to_end_tests/test_register_dataset_dummy.py
@@ -16,6 +16,8 @@ from database_test_utils import *
 def test_register_dataset(dummy_file):
     """Make a simple entry, and make sure the query returns the correct result"""
 
+    _NAME = "DESC:datasets:my_first_dataset"
+
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
@@ -23,7 +25,7 @@ def test_register_dataset(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_dataset",
+        _NAME,
         "0.0.1",
         description="This is my first DESC dataset",
     )
@@ -49,7 +51,7 @@ def test_register_dataset(dummy_file):
     )
 
     for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "my_first_dataset"
+        assert getattr(r, "dataset.name") == "DESC:datasets:my_first_dataset"
         assert getattr(r, "dataset.version_string") == "0.0.1"
         assert getattr(r, "dataset.version_major") == 0
         assert getattr(r, "dataset.version_minor") == 0
@@ -57,14 +59,16 @@ def test_register_dataset(dummy_file):
         assert getattr(r, "dataset.owner") == os.getenv("USER")
         assert getattr(r, "dataset.owner_type") == "user"
         assert getattr(r, "dataset.description") == "This is my first DESC dataset"
-        assert getattr(r, "dataset.relative_path") == "DESC/datasets/my_first_dataset"
+        assert getattr(r, "dataset.relative_path") == f"{_NAME}_0.0.1"
         assert getattr(r, "dataset.version_suffix") == None
         assert getattr(r, "dataset.data_org") == "dummy"
         assert i < 1
 
 
-def test_manual_name_and_vsuffix(dummy_file):
-    """Test setting the name and version suffix manually"""
+def test_manual_relpath_and_vsuffix(dummy_file):
+    """Test setting the relative path and version suffix manually"""
+
+    _NAME = "DESC:datasets:my_second_dataset"
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
@@ -73,42 +77,44 @@ def test_manual_name_and_vsuffix(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_second_dataset",
+        _NAME,
         "0.0.1",
-        name="custom name",
+        relative_path="my/custom/relative_path",
         version_suffix="custom_suffix",
     )
 
     # Query
     f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
     results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_suffix"], [f], return_format="cursorresult"
+        ["dataset.name", "dataset.version_suffix", "dataset.relative_path"],
+        [f],
+        return_format="cursorresult",
     )
 
     for i, r in enumerate(results):
-        assert getattr(r, "dataset.name") == "custom name"
+        assert getattr(r, "dataset.name") == _NAME
         assert getattr(r, "dataset.version_suffix") == "custom_suffix"
+        assert getattr(r, "dataset.relative_path") == "my/custom/relative_path"
         assert i < 1
 
     # Try to bump dataset with version suffix (should fail)
     with pytest.raises(ValueError, match="Cannot bump"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/my_second_dataset_bumped",
+            _NAME,
             "major",
-            name="custom name",
         )
 
 
 @pytest.mark.parametrize(
     "v_type,ans,name",
     [
-        ("major", "1.0.0", "my_first_dataset"),
-        ("minor", "1.1.0", "my_first_dataset"),
-        ("patch", "1.1.1", "my_first_dataset"),
-        ("patch", "1.1.2", "my_first_dataset"),
-        ("minor", "1.2.0", "my_first_dataset"),
-        ("major", "2.0.0", "my_first_dataset"),
+        ("major", "1.0.0", "DESC:datasets:my_first_dataset"),
+        ("minor", "1.1.0", "DESC:datasets:my_first_dataset"),
+        ("patch", "1.1.1", "DESC:datasets:my_first_dataset"),
+        ("patch", "1.1.2", "DESC:datasets:my_first_dataset"),
+        ("minor", "1.2.0", "DESC:datasets:my_first_dataset"),
+        ("major", "2.0.0", "DESC:datasets:my_first_dataset"),
     ],
 )
 def test_dataset_bumping(dummy_file, v_type, ans, name):
@@ -125,26 +131,30 @@ def test_dataset_bumping(dummy_file, v_type, ans, name):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/bumped_dataset_{v_type}_{name}_{ans.replace('.','_')}",
+        name,
         v_type,
-        name=name,
     )
 
     # Query
     f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
     results = datareg.Query.find_datasets(
-        ["dataset.name", "dataset.version_string"], [f], return_format="cursorresult"
+        ["dataset.name", "dataset.version_string", "dataset.relative_path"],
+        [f],
+        return_format="cursorresult",
     )
 
     for i, r in enumerate(results):
         assert getattr(r, "dataset.name") == name
         assert getattr(r, "dataset.version_string") == ans
+        assert getattr(r, "dataset.relative_path") == f"{name}_{ans}"
         assert i < 1
 
 
 @pytest.mark.parametrize("owner_type", ["user", "group", "project"])
 def test_dataset_owner_types(dummy_file, owner_type):
     """Test the different owner types"""
+
+    _NAME = f"DESC:datasets:owner_type={owner_type}"
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
@@ -153,7 +163,7 @@ def test_dataset_owner_types(dummy_file, owner_type):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/owner_type_{owner_type}",
+        _NAME,
         "0.0.1",
         owner_type=owner_type,
     )
@@ -161,11 +171,12 @@ def test_dataset_owner_types(dummy_file, owner_type):
     # Query
     f = datareg.Query.gen_filter("dataset.dataset_id", "==", d_id)
     results = datareg.Query.find_datasets(
-        ["dataset.owner_type"], [f], return_format="cursorresult"
+        ["dataset.owner_type", "dataset.name"], [f], return_format="cursorresult"
     )
 
     for i, r in enumerate(results):
         assert getattr(r, "dataset.owner_type") == owner_type
+        assert getattr(r, "dataset.name") == _NAME
         assert i < 1
 
 
@@ -187,7 +198,7 @@ def test_register_dataset_with_global_owner_set(dummy_file):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/global_user_dataset",
+        "DESC:datasets:global_user_dataset",
         "0.0.1",
         owner=None,
         owner_type=None,
@@ -222,13 +233,13 @@ def test_register_dataset_with_modified_default_execution(dummy_file):
 
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/execution_test_input",
+        "DESC:datasets:execution_test",
         "0.0.1",
     )
 
     d_id_2 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/execution_test",
+        "DESC:datasets:execution_test_2",
         "0.0.1",
         execution_name="Overwrite execution auto name",
         execution_description="Overwrite execution auto description",
@@ -292,10 +303,12 @@ def test_dataset_query_return_format(dummy_file, return_format_str, expected_typ
     tmp_src_dir, tmp_root_dir = dummy_file
     datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
 
+    _NAME = f"DESC:datasets:query_return_test_{return_format_str}"
+
     # Register a dataset
     d_id_1 = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/query_return_test_{return_format_str}",
+        _NAME,
         "3.2.1",
     )
 
@@ -319,10 +332,30 @@ def test_query_all(dummy_file):
     # Register a dataset
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/test_return_all",
+        "DESC:datasets:test_return_all",
         "3.2.1",
     )
 
     results = datareg.Query.find_datasets()
 
     assert results is not None
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["bad/name", "bad name", "b$dname", "*adname", "b&dname", "badname?", "bad\\name"],
+)
+def test_dataset_bad_name_string(dummy_file, name):
+    """Make sure illegal names get caught"""
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+
+    # Register a dataset
+    with pytest.raises(ValueError, match="Cannot have character"):
+        d_id_1 = _insert_dataset_entry(
+            datareg,
+            name,
+            "3.2.1",
+        )

--- a/tests/end_to_end_tests/test_register_dataset_external.py
+++ b/tests/end_to_end_tests/test_register_dataset_external.py
@@ -24,7 +24,7 @@ def test_bad_register_dataset_external(dummy_file):
     with pytest.raises(ValueError, match="require either a url or contact_email"):
         d_id = _insert_dataset_entry(
             datareg,
-            "DESC/datasets/my_first_external_dataset",
+            "DESC:datasets:my_first_external_dataset",
             "0.0.1",
             location_type="external",
         )
@@ -48,7 +48,7 @@ def test_register_dataset_external(dummy_file, contact_email, url, rel_path):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/{rel_path}",
+        f"DESC:datasets:{rel_path}",
         "0.0.1",
         location_type="external",
         contact_email=contact_email,

--- a/tests/end_to_end_tests/test_register_dataset_real_data.py
+++ b/tests/end_to_end_tests/test_register_dataset_real_data.py
@@ -28,7 +28,7 @@ def test_copy_data(dummy_file, data_org):
     # Add entry
     d_id = _insert_dataset_entry(
         datareg,
-        f"DESC/datasets/copy_real_{data_org}",
+        f"DESC:datasets:copy_real_{data_org}",
         "0.0.1",
         old_location=data_path,
         location_type="dataregistry",
@@ -76,11 +76,12 @@ def test_on_location_data(dummy_file, data_org, data_path, v_str, overwritable):
 
     d_id = _insert_dataset_entry(
         datareg,
-        data_path,
+        f"DESC:datasets:test_on_location_data_{data_org}",
         v_str,
         old_location=None,
         location_type="dataregistry",
         is_overwritable=overwritable,
+        relative_path=data_path,
     )
 
     f = datareg.Query.gen_filter("dataset.relative_path", "==", data_path)

--- a/tests/end_to_end_tests/test_register_pipeline.py
+++ b/tests/end_to_end_tests/test_register_pipeline.py
@@ -67,7 +67,7 @@ def test_pipeline_entry(dummy_file):
     # Datasets for stage 1
     d_id_1 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage1",
+        "DESC:datasets:my_first_pipeline_stage1",
         "0.0.1",
         execution_id=ex_id_1,
     )
@@ -85,7 +85,7 @@ def test_pipeline_entry(dummy_file):
     # Datasets for stage 2
     d_id_2 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage2a",
+        "DESC:datasets:my_first_pipeline_stage2a",
         "0.0.1",
         execution_id=ex_id_2,
     )
@@ -93,7 +93,7 @@ def test_pipeline_entry(dummy_file):
 
     d_id_3 = _insert_dataset_entry(
         datareg,
-        "DESC/datasets/my_first_pipeline_stage2b",
+        "DESC:datasets:my_first_pipeline_stage2b",
         "0.0.1",
         execution_id=ex_id_2,
     )

--- a/tests/unit_tests/test_registrar_util.py
+++ b/tests/unit_tests/test_registrar_util.py
@@ -7,6 +7,7 @@ from dataregistry.registrar.registrar_util import (
     _parse_version_string,
     _read_configuration_file,
     get_directory_info,
+    _relpath_from_name,
 )
 
 
@@ -158,3 +159,34 @@ def test_read_file(tmpdir, nchars, max_config_length, ans):
     # Make sure we raise an exception when the file doesn't exist
     with pytest.raises(FileNotFoundError, match="not found"):
         _read_configuration_file("i_dont_exist.txt", 10)
+
+@pytest.mark.parametrize(
+    "name,version_string,version_suffix,ans",
+    [
+        ("mydataset", "1.1.1", None, "mydataset_1.1.1"),
+        ("mydataset", "1.1.1", "v1", "mydataset_1.1.1_v1"),
+    ],
+)
+def test_relpath_from_name(name, version_string, version_suffix, ans):
+    """
+    Test dataset path construction
+    Datasets should come back with the format:
+        <root_dir>/<owner_type>/<owner>/<relative_path>
+    """
+
+    tmp = _relpath_from_name(name, version_string, version_suffix)
+    assert tmp == ans
+
+@pytest.mark.parametrize(
+    "rel_path,ans",
+    [
+        ("/testing/test", "test"),
+        ("./testing/test", "test"),
+        ("/testing/test/", "test"),
+        ("test", "test"),
+    ],
+)
+def test_name_from_relpath(rel_path,ans):
+    """Make sure names are extracted from paths correctly"""
+
+    assert _name_from_relpath(rel_path) == ans


### PR DESCRIPTION
This supersedes the old pull request.

Replace `relative_path` with `name` as the mandatory quantity when registering datasets. Users can still specify a manual `relative_path` during registration if requested. If no `relative_path` is given, one is generated automatically from the name and version.

When overwriting datasets, users must provide the `name` and `relative_path` for the entry they wish to overwrite. 

### Todo
- Update docs 