### PR TITLE
Don't allow registering via symlinks

### DIFF
--- a/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
+++ b/docs/source/tutorial_notebooks/getting_started_1_register_datasets.ipynb
@@ -248,6 +248,8 @@
     "\n",
     "In our example we have created a dummy text file as our dataset and ingested it into the data registry, however this can be any file or directory (directories will be recursively copied).\n",
     "\n",
+    "Note that the dataregistry does not support registering datasets through symbolic links (symlinks).\n",
+    "\n",
     "### Extra options\n",
     "\n",
     "All the `Registrar.dataset.register()` parameters we do not explicitly specify revert to their default values. For a full list of these options see the documentation [here](http://lsstdesc.org/dataregistry/reference_python.html#the-dregs-class). We would advise you to be as precise as possible when creating entries within the data registry. "

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -319,7 +319,6 @@ class DatasetTable(BaseTable):
         access_api_configuration=None,
         is_overwritable=False,
         old_location=None,
-        copy=True,
         verbose=False,
         owner=None,
         owner_type=None,
@@ -366,10 +365,6 @@ class DatasetTable(BaseTable):
 
             If None, dataset should already be at correct relative_path within
             the data registry.
-        copy : bool, optional
-            True to copy data from ``old_location`` into the data registry
-            (default behaviour).
-            False to create a symlink.
         verbose : bool, optional
             Provide some additional output information
         owner** : str, optional
@@ -457,7 +452,6 @@ class DatasetTable(BaseTable):
         access_api_configuration=None,
         is_overwritable=False,
         old_location=None,
-        copy=True,
         verbose=False,
         owner=None,
         owner_type=None,
@@ -631,6 +625,8 @@ class DatasetTable(BaseTable):
             loc = dest
 
         # Get metadata on dataset.
+        if os.path.islink(loc):
+            raise ValueError("dataregistry does not support symlinks")
         if os.path.isfile(loc):
             dataset_organization = "file"
         elif os.path.isdir(loc):

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -167,11 +167,6 @@ def get_parser():
         type=str,
     )
     arg_register_dataset.add_argument(
-        "--make_symlink",
-        help="Flag to make symlink to data rather than copy any files.",
-        action="store_true",
-    )
-    arg_register_dataset.add_argument(
         "--execution_name", help="Typically pipeline name or program name", type=str
     )
     arg_register_dataset.add_argument(

--- a/src/dataregistry_cli/register.py
+++ b/src/dataregistry_cli/register.py
@@ -47,7 +47,6 @@ def register_dataset(args):
         is_overwritable=args.is_overwritable,
         description=args.description,
         old_location=args.old_location,
-        copy=(not args.make_symlink),
         owner=args.owner,
         owner_type=args.owner_type,
         execution_name=args.execution_name,

--- a/tests/end_to_end_tests/database_test_utils.py
+++ b/tests/end_to_end_tests/database_test_utils.py
@@ -24,8 +24,10 @@ def dummy_file(tmp_path):
     |   - <source>
     |     - file1.txt
     |     - file2.txt
+    |     - file1_sym.txt (symlink)
     |     - <directory1>
     |       - file2.txt
+    |     - <directory1_sym> (symlink)
     |   - <root_dir>
     |     - <schema/user/uid>
     |       - <dummy_dir>
@@ -49,10 +51,20 @@ def dummy_file(tmp_path):
     tmp_src_dir = tmp_path / "source"
     tmp_src_dir.mkdir()
 
+    # Make two text files in source
     for i in range(2):
         f = tmp_src_dir / f"file{i+1}.txt"
         f.write_text("i am a dummy file")
 
+    # Make a symlink to `file1.txt`
+    link = tmp_src_dir / "file1_sym.txt"
+    link.symlink_to(tmp_src_dir / "file1.txt")
+
+    # Make a symlink to `directory1`
+    link = tmp_src_dir / "directory1_sym"
+    link.symlink_to(tmp_src_dir / "directory1")
+
+    # Make directory in source and a file within that directory
     p = tmp_src_dir / "directory1"
     p.mkdir()
     f = p / "file2.txt"
@@ -189,9 +201,6 @@ def _insert_dataset_entry(
         The dataset it created for this entry
     """
 
-    # Some defaults over all test datasets
-    make_sym_link = False
-
     # Add new entry.
     dataset_id, execution_id = datareg.Registrar.dataset.register(
         name,
@@ -200,7 +209,6 @@ def _insert_dataset_entry(
         creation_date=None,
         description=description,
         old_location=old_location,
-        copy=(not make_sym_link),
         execution_id=execution_id,
         verbose=True,
         owner=owner,
@@ -265,9 +273,6 @@ def _replace_dataset_entry(
         The dataset it created for this entry
     """
 
-    # Some defaults over all test datasets
-    make_sym_link = False
-
     # Add new entry.
     dataset_id, execution_id = datareg.Registrar.dataset.replace(
         name,
@@ -276,7 +281,6 @@ def _replace_dataset_entry(
         creation_date=None,
         description=description,
         old_location=old_location,
-        copy=(not make_sym_link),
         execution_id=execution_id,
         verbose=True,
         owner=owner,

--- a/tests/end_to_end_tests/test_register_dataset_real_data.py
+++ b/tests/end_to_end_tests/test_register_dataset_real_data.py
@@ -126,3 +126,25 @@ def test_on_location_data(dummy_file, data_org, data_path, v_str, overwritable):
             else:
                 assert getattr(r, "dataset.is_overwritable") == True
                 assert getattr(r, "dataset.is_overwritten") == True
+
+@pytest.mark.parametrize("link", ["file1_sym.txt", "directory1_sym"])
+def test_registering_symlinks(dummy_file, link):
+    """
+    The dataregistry does not allow registration through symlinks, make sure
+    this raises an error.
+    """
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=SCHEMA_VERSION)
+
+    data_path = str(tmp_src_dir / link)
+
+    with pytest.raises(ValueError, match="does not support symlinks"):
+        d_id = _insert_dataset_entry(
+            datareg,
+            f"DESC:datasets:test_register_symlink_{link}",
+            "0.0.1",
+            old_location=data_path,
+            location_type="dataregistry",
+        )


### PR DESCRIPTION
If a user tries to register a dataset via symbolic link, raise an error