### PR TITLE
Using "namespaces"

### DIFF
--- a/scripts/create_registry_schema.py
+++ b/scripts/create_registry_schema.py
@@ -326,7 +326,7 @@ keywords = load_preset_keywords()
 # Loop over each schema
 for schema in schema_list:
     # Connect to database to find out what the backend is
-    db_connection = DbConnection(args.config, schema, creation_mode=True)
+    db_connection = DbConnection(args.config, schema=schema)
     print(f"Database dialect is '{db_connection.dialect}'")
 
     if db_connection.dialect == "sqlite":

--- a/src/dataregistry/DataRegistry.py
+++ b/src/dataregistry/DataRegistry.py
@@ -14,11 +14,12 @@ class DataRegistry:
         owner=None,
         owner_type=None,
         config_file=None,
-        schema=None,
         root_dir=None,
         verbose=False,
         site=None,
-        production_mode=False,
+        namespace=None,
+        schema=None,
+        namespace_default_schema="working",
     ):
         """
         Primary data registry wrapper class.
@@ -55,13 +56,27 @@ class DataRegistry:
             Can be used instead of `root_dir`. Some predefined "sites" are
             built in, such as "nersc", which will set the `root_dir` to the
             data registry's default data location at NERSC.
-        production_mode : bool, optional
-            True to register/modify production schema entries
+        namespace : str, optional
+            Namespace to connect to. If None, the default namespace will be
+            used.
+        schema : str, optional
+            Schema to connect to, to connect directly to a chosen schema,
+            bypassing the namespace (creation of schemas or testing purposes only).
+        namespace_default_schema : str, optional
+            Which schema ("working" or "production") within the namespace to
+            use as the default. Queries will always probe both schemas. The
+            default schema is what is used during dataregistry entry creation,
+            modification and deletion.
         """
+
+        # Namespace schema must be either "working" or "production"
+        if namespace_default_schema not in ["working", "production"]:
+            raise ValueError("namespace_default_schema must be either working or production")
 
         # Establish connection to database
         self.db_connection = DbConnection(
-            config_file, schema=schema, verbose=verbose, production_mode=production_mode
+            config_file=config_file, schema=schema, verbose=verbose, namespace=namespace,
+            namespace_default_schema=namespace_default_schema
         )
 
         # Work out the location of the root directory

--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -652,9 +652,10 @@ class Query:
 
         Note this function only searches the "active" schema (unlike
         `find_datasets` which searches both the working and production schemas
-        jointly). This means when you are in `production_mode` you will search
-        the production schema, else (the default) you will search the working
-        schema.
+        jointly). The active schema has been defined during connection (either
+        via the `DataRegistry` or `DbConnection` object) via the
+        `namespace_default_schema` option (the "working" schema is the
+        default).
 
         Parameters
         ----------

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -143,11 +143,11 @@ class DatasetTable(BaseTable):
         if kwargs_dict["owner_type"] == "production":
             if kwargs_dict["is_overwritable"]:
                 raise ValueError("Cannot overwrite production entries")
-            if (not self.db_connection.production_mode) and (
+            if (not self.db_connection.active_schema_is_production) and (
                 not kwargs_dict["test_production"]
             ):
                 raise ValueError(
-                    "Must be in `production_mode` to write to production schema'"
+                    "To write to production schema, active schema must be production"
                 )
 
             # The only owner allowed for production datasets is "production"
@@ -155,7 +155,7 @@ class DatasetTable(BaseTable):
                 raise ValueError("`owner` for production datasets must be 'production'")
         else:
             if self._dialect != "sqlite" and not kwargs_dict["test_production"]:
-                if self.db_connection.production_mode:
+                if self.db_connection.active_schema_is_production:
                     raise ValueError(
                         "Only owner_type='production' can go in the production schema"
                     )

--- a/src/dataregistry/schema/__init__.py
+++ b/src/dataregistry/schema/__init__.py
@@ -3,4 +3,5 @@ from .load_schema import (
     load_preset_keywords,
     DEFAULT_SCHEMA_WORKING,
     DEFAULT_SCHEMA_PRODUCTION,
+    DEFAULT_NAMESPACE,
 )

--- a/src/dataregistry/schema/default_schema_names.yaml
+++ b/src/dataregistry/schema/default_schema_names.yaml
@@ -1,2 +1,3 @@
+namespace: lsst_desc
 working: lsst_desc_working
 production: lsst_desc_production

--- a/src/dataregistry/schema/load_schema.py
+++ b/src/dataregistry/schema/load_schema.py
@@ -81,6 +81,17 @@ def get_default_schema_production():
 
     return yaml_data["production"]
 
+def get_default_namespace():
+    yaml_file_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "default_schema_names.yaml"
+    )
+    with open(yaml_file_path, "r") as file:
+        yaml_data = yaml.safe_load(file)
+
+    return yaml_data["namespace"]
+
 
 DEFAULT_SCHEMA_WORKING = get_default_schema_working()
 DEFAULT_SCHEMA_PRODUCTION = get_default_schema_production()
+DEFAULT_NAMESPACE = get_default_namespace()
+

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import argparse
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from .register import register_dataset
 from .delete import delete_dataset
 from .query import dregs_ls
@@ -30,13 +30,17 @@ def _add_generic_arguments(parser_obj):
     )
     parser_obj.add_argument(
         "--schema",
-        default=f"{DEFAULT_SCHEMA_WORKING}",
-        help="Which working schema to connect to",
+        help="Which schema to connect to",
     )
     parser_obj.add_argument(
-        "--production_mode",
-        action="store_true",
-        help="Flag to write/modify production entries",
+        "--namespace",
+        default=DEFAULT_NAMESPACE,
+        help="Which namespace to connect to",
+    )
+    parser_obj.add_argument(
+        "--namespace_default_schema",
+        default="working",
+        help="Which schema to default to in the namespace (working is default)",
     )
 
 

--- a/src/dataregistry_cli/delete.py
+++ b/src/dataregistry_cli/delete.py
@@ -19,8 +19,10 @@ def delete_dataset(args):
         Path to root_dir
     args.site : str
         Look up root_dir using a site
-    args.production_mode : bool
-        True to register/modify production entries
+    args.namespace_default_schema : str
+        Which schema to default to within the namespace
+    args.namespace : str
+        Which namespace to connect to
 
     args.dataset_id: int
         The dataset_id of the dataset we are deleting
@@ -32,7 +34,8 @@ def delete_dataset(args):
         schema=args.schema,
         root_dir=args.root_dir,
         site=args.site,
-        production_mode=args.production_mode,
+        namespace_default_schema=args.namespace_default_schema,
+        namespace=args.namespace
     )
 
     # Deleting directly using the dataset ID

--- a/src/dataregistry_cli/modify.py
+++ b/src/dataregistry_cli/modify.py
@@ -29,8 +29,10 @@ def modify_dataset(args):
         The column in the dataset table we are modifying
     args.value : str
         The updated value
-    args.production_mode : bool
-        True to register/modify production entries
+    args.namespace_default_schema : str
+        Which schema to default to in the namespace
+    args.namespace : str
+        Which namespace to connect to
     """
 
     # Connect to database.
@@ -39,7 +41,8 @@ def modify_dataset(args):
         schema=args.schema,
         root_dir=args.root_dir,
         site=args.site,
-        production_mode=args.production_mode,
+        namespace_default_schema=args.namespace_default_schema,
+        namespace=args.namespace,
     )
 
     # Modify dataset.

--- a/src/dataregistry_cli/register.py
+++ b/src/dataregistry_cli/register.py
@@ -19,8 +19,10 @@ def register_dataset(args):
         Path to root_dir
     args.site : str
         Look up root_dir using a site
-    args.production_mode : bool
-        True to register/modify production entries
+    args.namespace_default_schema : str
+        Which schema to default to in the namespace
+    args.namespace : str
+        Which namespace to connect to
 
     Information about the arguments that go into `register_dataset` can be
     found in `src/cli/cli.py` or by running `dregs --help`.
@@ -36,7 +38,8 @@ def register_dataset(args):
         schema=args.schema,
         root_dir=args.root_dir,
         site=args.site,
-        production_mode=args.production_mode,
+        namespace_default_schema=args.namespace_default_schema,
+        namespace=args.namespace
     )
 
     # Register new dataset.

--- a/tests/end_to_end_tests/database_test_utils.py
+++ b/tests/end_to_end_tests/database_test_utils.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
 
 __all__ = [
     "dummy_file",
@@ -11,6 +10,7 @@ __all__ = [
     "_replace_dataset_entry",
 ]
 
+DEFAULT_SCHEMA_WORKING = "lsst_desc_working"
 
 @pytest.fixture
 def dummy_file(tmp_path):

--- a/tests/end_to_end_tests/test_cli.py
+++ b/tests/end_to_end_tests/test_cli.py
@@ -3,7 +3,7 @@ import shlex
 import dataregistry_cli.cli as cli
 import pytest
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import dummy_file
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
@@ -17,16 +17,16 @@ def test_simple_query(dummy_file):
 
     # Register a dataset
     cmd = "register dataset my_cli_dataset 0.0.1 --location_type dummy"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Update the registered dataset
     cmd = "register dataset my_cli_dataset patch --location_type dummy"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset")
     results = datareg.Query.find_datasets(
         ["dataset.name", "dataset.version_string"], [f]
@@ -47,11 +47,11 @@ def test_dataset_entry_with_execution(dummy_file):
     cmd += " --creation_date '2020-01-01'"
     cmd += " --input_datasets 1 2 --execution_name 'I have given the execution a name'"
     cmd += " --is_overwritable"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset3")
     results = datareg.Query.find_datasets(
         [
@@ -80,7 +80,7 @@ def test_production_entry(dummy_file):
         # Register a dataset
         cmd = "register dataset my_production_cli_dataset 0.1.2 --location_type dummy"
         cmd += " --owner_type production --owner production"
-        cmd += f" --production_mode --root_dir {str(tmp_root_dir)}"
+        cmd += f" --namespace_default_schema production --root_dir {str(tmp_root_dir)}"
         cli.main(shlex.split(cmd))
 
         # Check
@@ -99,11 +99,11 @@ def test_delete_dataset_by_id(dummy_file,monkeypatch):
 
     # Register a dataset
     cmd = "register dataset my_cli_dataset_to_delete 0.0.1 --location_type dummy"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Find the dataset id
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_delete")
     results = datareg.Query.find_datasets(["dataset.dataset_id"], [f])
     assert len(results["dataset.dataset_id"]) == 1, "Bad result from query dcli4"
@@ -111,12 +111,12 @@ def test_delete_dataset_by_id(dummy_file,monkeypatch):
 
     # Delete the dataset
     cmd = f"delete dataset_by_id {d_id}"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     monkeypatch.setattr('builtins.input', lambda _: "y")
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_delete")
     results = datareg.Query.find_datasets(
         [
@@ -147,13 +147,13 @@ def test_delete_dataset_by_name(dummy_file,monkeypatch):
 
     # Register a dataset
     cmd = f"register dataset {DNAME} {DVERSION} --location_type dummy"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cmd += f" --owner {DOWNER} --owner_type {DOWNER_TYPE}"
     monkeypatch.setattr('builtins.input', lambda _: "y")
     cli.main(shlex.split(cmd))
 
     # Find the dataset id
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", DNAME)
     results = datareg.Query.find_datasets(["dataset.dataset_id"], [f])
     assert len(results["dataset.dataset_id"]) == 1, "Bad result from query dcli4"
@@ -161,11 +161,11 @@ def test_delete_dataset_by_name(dummy_file,monkeypatch):
 
     # Delete the dataset
     cmd = f"delete dataset {DNAME} {DVERSION} {DOWNER} {DOWNER_TYPE}"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", DNAME)
     results = datareg.Query.find_datasets(
         [
@@ -191,11 +191,11 @@ def test_dataset_entry_with_keywords(dummy_file):
     # Register a dataset with many options
     cmd = "register dataset my_cli_dataset_keywords 1.0.0 --location_type dummy"
     cmd += " --is_overwritable --keywords simulation observation"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_keywords")
     results = datareg.Query.find_datasets(
         [
@@ -220,11 +220,11 @@ def test_modify_dataset(dummy_file):
 
     # Register a dataset
     cmd = "register dataset my_cli_dataset_to_modify 0.0.1 --location_type dummy"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Find the dataset id
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_modify")
     results = datareg.Query.find_datasets(["dataset.dataset_id"], [f])
     assert len(results["dataset.dataset_id"]) == 1, "Bad result from query dcli5"
@@ -232,11 +232,11 @@ def test_modify_dataset(dummy_file):
 
     # Modify dataset
     cmd = f"modify dataset {d_id} description 'Updated CLI desc'"
-    cmd += f" --schema {DEFAULT_SCHEMA_WORKING} --root_dir {str(tmp_root_dir)}"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
     cli.main(shlex.split(cmd))
 
     # Check
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     f = datareg.Query.gen_filter("dataset.name", "==", "my_cli_dataset_to_modify")
     results = datareg.Query.find_datasets(
         [

--- a/tests/end_to_end_tests/test_database_functions.py
+++ b/tests/end_to_end_tests/test_database_functions.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 
@@ -15,7 +15,7 @@ def test_get_dataset_absolute_path(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     dset_name = "DESC:datasets:get_dataset_absolute_path_test"
     dset_ownertype = "group"
@@ -41,7 +41,7 @@ def test_get_dataset_absolute_path(dummy_file):
     else:
         assert v == os.path.join(
             str(tmp_root_dir),
-            DEFAULT_SCHEMA_WORKING,
+            datareg.db_connection.active_schema,
             dset_ownertype,
             dset_owner,
             dset_relpath,
@@ -58,7 +58,7 @@ def test_find_entry(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Make a dataset
     d_id = _insert_dataset_entry(datareg, "test_find_entry:dataset", "0.0.1")
@@ -94,7 +94,7 @@ def test_get_modifiable_columns(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     mod_list = datareg.Registrar.dataset.get_modifiable_columns()
     assert "description" in mod_list
@@ -108,7 +108,7 @@ def test_get_keywords(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     keywords = datareg.Registrar.dataset.get_keywords()
 

--- a/tests/end_to_end_tests/test_delete_dataset.py
+++ b/tests/end_to_end_tests/test_delete_dataset.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.registrar.dataset_util import get_dataset_status
 from dataregistry.registrar.registrar_util import _form_dataset_path
 
@@ -14,7 +14,7 @@ def test_delete_dataset_bad_entry(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Make sure we raise an exception trying to delete a dataset that doesn't exist
     with pytest.raises(ValueError, match="not found in"):
@@ -43,7 +43,7 @@ def test_delete_dataset_entry(dummy_file, is_dummy, dataset_name, delete_by_id):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Where is the real data?
     if is_dummy:
@@ -105,7 +105,7 @@ def test_delete_dataset_entry(dummy_file, is_dummy, dataset_name, delete_by_id):
             results["dataset.owner_type"][0],
             results["dataset.owner"][0],
             results["dataset.relative_path"][0],
-            schema=DEFAULT_SCHEMA_WORKING,
+            schema=datareg.db_connection.active_schema,
             root_dir=str(tmp_root_dir),
         )
         if dataset_name == "real_dataset_to_delete":

--- a/tests/end_to_end_tests/test_keywords.py
+++ b/tests/end_to_end_tests/test_keywords.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
 from dataregistry.registrar.registrar_util import _form_dataset_path
 
@@ -23,7 +23,7 @@ def test_register_dataset_with_bad_keywords(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Test case where keywords are not strings
     with pytest.raises(ValueError, match="not a valid keyword string"):
@@ -53,7 +53,7 @@ def test_register_dataset_with_keywords(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Register two datasets with keywords
     d_id = _insert_dataset_entry(
@@ -96,7 +96,7 @@ def test_modify_dataset_with_keywords(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Register a dataset with keywords
     d_id = _insert_dataset_entry(

--- a/tests/end_to_end_tests/test_modify.py
+++ b/tests/end_to_end_tests/test_modify.py
@@ -1,6 +1,6 @@
 import pytest
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 
@@ -19,7 +19,7 @@ def test_modify_dataset(dummy_file, dataset_name, column, new_value):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -54,7 +54,7 @@ def test_modify_execution(dummy_file, execution_name, column, new_value):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     e_id = _insert_execution_entry(
@@ -80,7 +80,7 @@ def test_modify_not_allowed(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(

--- a/tests/end_to_end_tests/test_production_schema.py
+++ b/tests/end_to_end_tests/test_production_schema.py
@@ -4,14 +4,14 @@ import sys
 import pytest
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.db_basic import DbConnection
 
 from database_test_utils import *
 
 # This is just to see what backend we are using
 # Remember no production schema when using sqlite backend
-db_connection = DbConnection(None, schema=DEFAULT_SCHEMA_WORKING)
+db_connection = DbConnection(config_file=None, namespace=DEFAULT_NAMESPACE)
 
 
 @pytest.mark.skipif(
@@ -22,9 +22,10 @@ def test_register_with_production_dependencies(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
     datareg_prod = DataRegistry(
-        root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING, production_mode=True
+        root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE,
+        namespace_default_schema="production"
     )
 
     # Make a dataset in each schema
@@ -80,7 +81,8 @@ def test_production_schema_register(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING, production_mode=True)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE,
+            namespace_default_schema="production")
 
     d_id = _insert_dataset_entry(
         datareg,
@@ -114,7 +116,8 @@ def test_production_schema_bad_register(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING, production_mode=True)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE,
+            namespace_default_schema="production")
 
     # Try to register dataset without production owner type
     with pytest.raises(ValueError, match="can go in the production schema"):

--- a/tests/end_to_end_tests/test_query.py
+++ b/tests/end_to_end_tests/test_query.py
@@ -5,7 +5,7 @@ import sqlalchemy
 from sqlalchemy import inspect
 
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from database_test_utils import *
 
 # Establish connection to database (default schema)
@@ -36,7 +36,7 @@ def test_query_all(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -61,7 +61,7 @@ def test_query_between_columns(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     _NAME = "DESC:datasets:test_query_between_columns"
@@ -117,7 +117,7 @@ def test_query_name(dummy_file, op, qstr, ans, tag):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     for tmp_tag in ["first", "second", "third"]:

--- a/tests/end_to_end_tests/test_register_dataset_alias.py
+++ b/tests/end_to_end_tests/test_register_dataset_alias.py
@@ -1,5 +1,5 @@
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 import pytest
@@ -9,7 +9,7 @@ def test_register_dataset_alias(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add two dataset
     d_id = _insert_dataset_entry(

--- a/tests/end_to_end_tests/test_register_dataset_dummy.py
+++ b/tests/end_to_end_tests/test_register_dataset_dummy.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
 from dataregistry.registrar.registrar_util import _form_dataset_path
 
@@ -23,7 +23,7 @@ def test_register_dataset_defaults(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -92,7 +92,7 @@ def test_register_dataset_manual(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -169,7 +169,7 @@ def test_dataset_bumping(dummy_file, v_type, ans):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -203,7 +203,7 @@ def test_dataset_owner_types(dummy_file, owner_type):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(
@@ -236,7 +236,7 @@ def test_register_dataset_with_global_owner_set(dummy_file):
     tmp_src_dir, tmp_root_dir = dummy_file
     datareg = DataRegistry(
         root_dir=str(tmp_root_dir),
-        schema=DEFAULT_SCHEMA_WORKING,
+        namespace=DEFAULT_NAMESPACE,
         owner="DESC group",
         owner_type="group",
     )
@@ -277,7 +277,7 @@ def test_register_dataset_with_modified_default_execution(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     d_id_1 = _insert_dataset_entry(
         datareg,
@@ -349,7 +349,7 @@ def test_dataset_query_return_format(dummy_file, return_format_str, expected_typ
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     _NAME = f"DESC:datasets:query_return_test_{return_format_str}"
 
@@ -375,7 +375,7 @@ def test_query_all(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Register a dataset
     d_id_1 = _insert_dataset_entry(
@@ -398,7 +398,7 @@ def test_dataset_bad_name_string(dummy_file, name):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Register a dataset
     with pytest.raises(ValueError, match="Cannot have character"):

--- a/tests/end_to_end_tests/test_register_dataset_external.py
+++ b/tests/end_to_end_tests/test_register_dataset_external.py
@@ -6,7 +6,7 @@ import pytest
 import sqlalchemy
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
 from dataregistry.registrar.registrar_util import _form_dataset_path
 
@@ -18,7 +18,7 @@ def test_bad_register_dataset_external(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     with pytest.raises(ValueError, match="require either a url or contact_email"):
@@ -43,7 +43,7 @@ def test_register_dataset_external(dummy_file, contact_email, url, rel_path):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     d_id = _insert_dataset_entry(

--- a/tests/end_to_end_tests/test_register_dataset_real_data.py
+++ b/tests/end_to_end_tests/test_register_dataset_real_data.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 from dataregistry.registrar.dataset_util import get_dataset_status, set_dataset_status
 from dataregistry.registrar.registrar_util import _form_dataset_path
 from dataregistry.exceptions import DataRegistryRootDirBadState
@@ -17,7 +17,7 @@ def test_copy_data(dummy_file, data_org):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # File/directory we are copying in
     if data_org == "file":
@@ -62,7 +62,7 @@ def test_on_location_data(dummy_file, data_org, data_path):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     d_id = _insert_dataset_entry(
         datareg,
@@ -102,7 +102,7 @@ def test_registering_symlinks(dummy_file, link):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     data_path = str(tmp_src_dir / link)
 
@@ -125,7 +125,7 @@ def test_registering_bad_relative_path(dummy_file, link):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     data_path = str(tmp_src_dir / link)
 
@@ -157,7 +157,7 @@ def test_registering_bad_relative_path_2(dummy_file, link):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     data_path = str(tmp_src_dir / link)
 
@@ -196,7 +196,7 @@ def test_registering_deleted_relative_path(dummy_file, link):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     data_path = str(tmp_src_dir / link)
 
@@ -270,7 +270,7 @@ def test_registering_data_already_there(dummy_file, link, dest):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     data_path = str(tmp_src_dir / link)
 

--- a/tests/end_to_end_tests/test_register_execution.py
+++ b/tests/end_to_end_tests/test_register_execution.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 
@@ -28,7 +28,7 @@ def test_register_execution_with_config_file(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add entry
     _make_dummy_config(tmp_src_dir)

--- a/tests/end_to_end_tests/test_register_pipeline.py
+++ b/tests/end_to_end_tests/test_register_pipeline.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 import yaml
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 
@@ -54,7 +54,7 @@ def test_pipeline_entry(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Execution for stage 1
     ex_id_1 = _insert_execution_entry(

--- a/tests/end_to_end_tests/test_replace_dataset.py
+++ b/tests/end_to_end_tests/test_replace_dataset.py
@@ -1,5 +1,5 @@
 from dataregistry import DataRegistry
-from dataregistry.schema import DEFAULT_SCHEMA_WORKING
+from dataregistry.schema import DEFAULT_NAMESPACE
 
 from database_test_utils import *
 import pytest
@@ -10,7 +10,7 @@ def test_register_dataset_twice(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add two dataset
     d_id = _insert_dataset_entry(
@@ -123,7 +123,7 @@ def test_replace_dataset(dummy_file, _REL_PATH, name_tag):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add a dataset
     d_id = _insert_dataset_entry(
@@ -172,7 +172,7 @@ def test_replacing_deleted_dataset(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     _NAME = "DESC:dataset:test_replacing_deleted_dataset"
 
@@ -201,7 +201,7 @@ def test_replacing_non_overwritable_dataset(dummy_file):
 
     # Establish connection to database
     tmp_src_dir, tmp_root_dir = dummy_file
-    datareg = DataRegistry(root_dir=str(tmp_root_dir), schema=DEFAULT_SCHEMA_WORKING)
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
 
     # Add dataset
     d_id = _insert_dataset_entry(


### PR DESCRIPTION
Change the nomenclature away from "schema" to "namespace". This means that users "connect" to a `namespace`, which is a collection of a "working" and "production" schema pair.

The registry namespace is assume to have been created in a standard way, i.e., a working schema in the format `<namespace>_<working>` and a production schema in the format `<namespace>_<production>`.

There is very little changes to the working, and if using defaults no changes as the working all remains under the hood.

Users can connected through the `DataRegistry` object (or directly with the `DbConnection` object) as before. Now rather than providing a `schema=` they provide `namespace=` (not including this flat reverts to the default namespace which is `lsst_desc`). Connecting to a namespace connects to both the working and production schema of that namespace.

You can, if needed, directly connect to a particular schema, using `schema=` during the connection. However this is only really for schema creation, and testing. This removes the need for `creation_mode=True` flag.

When connected to a `namespace`, both the working and production schemas are searched during queries. To decide which `schema` to register/modify/delete entries for during that instance, the user can set `namespace_default_schema` during connection (which can be either "working" or "production", default is "working"). This replaces `production_mode=True` flag.  

### Changes
- Users connect to a `namespace` rather than a `schema`
- There is no more concept of `DEFAULT_WORKING_SCHEMA`, it is now `DEFAULT_NAMESPACE`
- `creation_mode` and `production_mode` flags removed.
- Tests updated

### Todo
- Remove any other instances of `DEFAULT_SCHEMA`
- Add test that connects to schema directly, not using namespace
- Update docs with new conenction info

### Think about
This has now moved to the internal assumption that there will always be a "working" and "production" schema pair, which I think is ok. The code could be simplified further using this assumption, for example no need to search the provenanace table for the paired production schema, we know it will be `<namespace>_production`. This does mean that things would have to be tweaked if you wanted multiple schemas connected to the same production schema.