### PR TITLE
Keyword case sensitivity

### DIFF
--- a/src/dataregistry/db_basic.py
+++ b/src/dataregistry/db_basic.py
@@ -518,12 +518,14 @@ def _insert_keyword(
     """
     Write a row to a keyword table.
 
+    Keywords are always ingested as lower case.
+
     Parameters
     ----------
     db_connection : DbConnection class
         Conenction to the database
     keyword : str
-        Keyword to add
+        Keyword to add (added in lower case form regardless of input)
     system : bool
         True if this is a preset system keyword (False for user custom keyword)
     creator_uid : int, optional
@@ -534,8 +536,12 @@ def _insert_keyword(
         Id of new row in keyword table
     """
 
+    if not isinstance(keyword, str):
+        print(f"Only string keywords can be inserted")
+        return
+
     values = dict()
-    values["keyword"] = keyword
+    values["keyword"] = keyword.lower()
     values["system"] = system
     if creator_uid is None:
         values["creator_uid"] = os.getenv("USER")

--- a/src/dataregistry/registrar/dataset.py
+++ b/src/dataregistry/registrar/dataset.py
@@ -160,8 +160,10 @@ class DatasetTable(BaseTable):
                         "Only owner_type='production' can go in the production schema"
                     )
 
-        # Validate the keywords (make sure they are registered)
+        # Keywords
         if len(kwargs_dict["keywords"]) > 0:
+
+            # Validate the keywords (make sure they are registered)
             kwargs_dict["keyword_ids"] = self._validate_keywords(
                 kwargs_dict["keywords"]
             )
@@ -955,7 +957,7 @@ class DatasetTable(BaseTable):
         keyword_table = self._get_table_metadata("keyword")
 
         stmt = select(keyword_table.c.keyword_id).where(
-            keyword_table.c.keyword.in_(keywords)
+            keyword_table.c.keyword.in_([x.lower() for x in keywords])
         )
 
         with self._engine.connect() as conn:
@@ -989,10 +991,6 @@ class DatasetTable(BaseTable):
         # Make sure things are valid
         if not isinstance(keywords, list):
             raise ValueError("Passed keywords object must be a list")
-
-        for k in keywords:
-            if not isinstance(k, str):
-                raise ValueError(f"Keyword {k} is not a valid string")
 
         if len(keywords) == 0:
             return

--- a/tests/end_to_end_tests/test_database_functions.py
+++ b/tests/end_to_end_tests/test_database_functions.py
@@ -142,5 +142,9 @@ def test_insert_keywords(dummy_file, mykeyword):
     _insert_keyword(datareg.db_connection, mykeyword, True)
 
     # Second time should fail, keywords are unique
-    with pytest.raises(IntegrityError, match="duplicate key value"):
-        _insert_keyword(datareg.db_connection, mykeyword, True)
+    if datareg.db_connection._dialect == "sqlite":
+        with pytest.raises(IntegrityError, match="UNIQUE constraint failed"):
+            _insert_keyword(datareg.db_connection, mykeyword, True)
+    else:
+        with pytest.raises(IntegrityError, match="duplicate key value"):
+            _insert_keyword(datareg.db_connection, mykeyword, True)

--- a/tests/end_to_end_tests/test_database_functions.py
+++ b/tests/end_to_end_tests/test_database_functions.py
@@ -3,9 +3,10 @@ import os
 import pytest
 from dataregistry import DataRegistry, DbConnection
 from dataregistry.schema import DEFAULT_NAMESPACE
+from dataregistry.db_basic import _insert_keyword
 
 from database_test_utils import *
-
+from sqlalchemy.exc import IntegrityError
 
 # This is just to see what backend we are using
 # Remember no production schema when using sqlite backend
@@ -124,3 +125,22 @@ def test_get_keywords(dummy_file):
 
     assert "simulation" in keywords
     assert "observation" in keywords
+
+@pytest.mark.parametrize("mykeyword", ["KeYwOrD", "anotherkeyword"])
+def test_insert_keywords(dummy_file, mykeyword):
+    """
+    Test inserting a keyword with `_insert_keyword`
+
+
+    Make sure case sensitivity is ignored (keywords are always entered as lower case
+    """
+    
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+    datareg = DataRegistry(root_dir=str(tmp_root_dir), namespace=DEFAULT_NAMESPACE)
+
+    _insert_keyword(datareg.db_connection, mykeyword, True)
+
+    # Second time should fail, keywords are unique
+    with pytest.raises(IntegrityError, match="duplicate key value"):
+        _insert_keyword(datareg.db_connection, mykeyword, True)

--- a/tests/end_to_end_tests/test_keywords.py
+++ b/tests/end_to_end_tests/test_keywords.py
@@ -43,12 +43,15 @@ def test_register_dataset_with_bad_keywords(dummy_file):
             keywords=["bad_keyword"],
         )
 
-
-def test_register_dataset_with_keywords(dummy_file):
+@pytest.mark.parametrize("mykeyword", ["simulation", "SiMuLaTiOn"])
+def test_register_dataset_with_keywords(dummy_file, mykeyword):
     """
     Register some basic datasets with keywords.
 
     Then query the registry on a keyword and make sure we get our datasets back.
+
+    Keywords should also be case insensitive, i.e., all keywords are stored in
+    the database as lowercase. Test this also.
     """
 
     # Establish connection to database
@@ -58,20 +61,20 @@ def test_register_dataset_with_keywords(dummy_file):
     # Register two datasets with keywords
     d_id = _insert_dataset_entry(
         datareg,
-        "DESC:datasets:my_first_dataset_with_keywords",
+        f"DESC:datasets:my_first_dataset_with_keyword_{mykeyword}",
         "0.0.1",
-        keywords=["simulation", "observation"],
+        keywords=[mykeyword, "observation"],
     )
 
     d_id2 = _insert_dataset_entry(
         datareg,
-        "DESC:datasets:my_second_dataset_with_keywords",
+        f"DESC:datasets:my_second_dataset_with_keyword_{mykeyword}",
         "0.0.1",
-        keywords=["simulation"],
+        keywords=[mykeyword],
     )
 
     # Query on the "simulation" keyword
-    f = datareg.Query.gen_filter("keyword.keyword", "==", "simulation")
+    f = datareg.Query.gen_filter("keyword.keyword", "==", mykeyword.lower())
     results = datareg.Query.find_datasets(
         ["dataset.dataset_id", "keyword.keyword"],
         [f],
@@ -82,7 +85,7 @@ def test_register_dataset_with_keywords(dummy_file):
     for tmp_id in [d_id, d_id2]:
         assert tmp_id in results["dataset.dataset_id"]
     for tmp_k in results["keyword.keyword"]:
-        assert tmp_k == "simulation"
+        assert tmp_k == mykeyword.lower()
 
 
 def test_modify_dataset_with_keywords(dummy_file):


### PR DESCRIPTION
Make it so that `keywords` are always ingested into the `keyword` table in lower case, regardless of the user input. This prevents unwanted duplication of keywords through case differences.

Note that when querying, sqlalchemy+postgres is still case sensitive (both `=` and `==`), so when querying for keywords you still have to be case sensitive, in this case lower case. We could change the querying for keywords to remove case sensitivity also.