### PR TITLE
Add missing f-string indicator in query.py

### DIFF
--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -516,7 +516,7 @@ class Query:
             "=",
             "!=",
         ]:
-            raise ValueError('check_filter: Cannot apply "{f[1]}" to "{f[0]}"')
+            raise ValueError(f'check_filter: Cannot apply "{f[1]}" to "{f[0]}"')
         else:
             value = f[2]
 


### PR DESCRIPTION
There is a missing "f" in an error message that makes the response a bit less clear.