### PR TITLE
Add CLI command to list projects

### DIFF
--- a/src/dataregistry/query.py
+++ b/src/dataregistry/query.py
@@ -546,6 +546,19 @@ class Query:
         )
         return results["keyword.keyword"]
 
+    def get_project_list(self, query_mode=None):
+        """Get list of project owners from the dataset table"""
+
+        if not query_mode:
+            query_mode = self.db_connection._query_mode
+
+        results = self.find_datasets(
+            property_names=["dataset.owner"],
+            filters=[("dataset.owner_type", "==", "project")],
+            schema_mode=query_mode,
+        )
+        return sorted(set(results["dataset.owner"]))
+
     def find_datasets(
         self,
         property_names=None,

--- a/src/dataregistry_cli/cli.py
+++ b/src/dataregistry_cli/cli.py
@@ -94,6 +94,11 @@ def get_parser():
     )
     _add_generic_arguments(arg_show_keywords, add_entry_mode=False, add_query_mode=True)
 
+    arg_show_projects = arg_show_sub.add_parser(
+        "projects", help="Show list of project owners"
+    )
+    _add_generic_arguments(arg_show_projects, add_entry_mode=False, add_query_mode=True)
+
     # ----------
     # Query (ls)
     # ----------
@@ -417,6 +422,8 @@ def main(cmd=None):
     elif args.subcommand == "show":
         if args.show_type == "keywords":
             dregs_show("keywords", args)
+        elif args.show_type == "projects":
+            dregs_show("projects", args)
 
     # Print absolute path for one dataset
     elif args.subcommand == "path":

--- a/src/dataregistry_cli/show.py
+++ b/src/dataregistry_cli/show.py
@@ -42,8 +42,8 @@ def dregs_show(show_what, args):
             print('Please use "working" (the default) or "production".')
             return
 
-        print(f"Avaliable keywords:")
+        print("Available keywords:")
         print(datareg.Query.get_keyword_list())
     elif show_what == "projects":
-        print(f"Available projects:")
+        print("Available projects:")
         print(datareg.Query.get_project_list())

--- a/src/dataregistry_cli/show.py
+++ b/src/dataregistry_cli/show.py
@@ -44,3 +44,6 @@ def dregs_show(show_what, args):
 
         print(f"Avaliable keywords:")
         print(datareg.Query.get_keyword_list())
+    elif show_what == "projects":
+        print(f"Available projects:")
+        print(datareg.Query.get_project_list())

--- a/tests/end_to_end_tests/test_cli.py
+++ b/tests/end_to_end_tests/test_cli.py
@@ -336,3 +336,37 @@ def test_path_dataset_by_id(dummy_file, capsys):
     captured = capsys.readouterr()
 
     assert captured.out.strip() == expected_path
+
+
+def test_show_projects(dummy_file, capsys):
+    """List project owners through the CLI show command."""
+
+    # Establish connection to database
+    tmp_src_dir, tmp_root_dir = dummy_file
+
+    # Register datasets with project owners and one non-project owner
+    cmd = "register dataset project_dataset_a 0.0.1 --location_type dummy"
+    cmd += " --owner project_alpha --owner_type project"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+
+    cmd = "register dataset project_dataset_b 0.0.1 --location_type dummy"
+    cmd += " --owner project_beta --owner_type project"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+
+    cmd = "register dataset user_dataset 0.0.1 --location_type dummy"
+    cmd += " --owner user_alpha --owner_type user"
+    cmd += f" --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+
+    # Clear prior command output and run the show command
+    capsys.readouterr()
+    cmd = f"show projects --namespace {DEFAULT_NAMESPACE} --root_dir {str(tmp_root_dir)}"
+    cli.main(shlex.split(cmd))
+    captured = capsys.readouterr()
+
+    assert "Available projects:" in captured.out
+    assert "project_alpha" in captured.out
+    assert "project_beta" in captured.out
+    assert "user_alpha" not in captured.out


### PR DESCRIPTION
This adds a new sub-command of `dregs show`, `dregs show projects` which lists all projects in the DB. I have occasionally had trouble remembering what I named a project and this is a quick helper to remind me!

(written with copilot).